### PR TITLE
Fixes #32 get parameter by name

### DIFF
--- a/src/code/findTableIndex.R
+++ b/src/code/findTableIndex.R
@@ -34,18 +34,33 @@ findTableIndex <- function(path_id = numeric(0), tableID = numeric(0), isReferen
   		indx <- 1:counts
   		if (path_id != '*')
   		{
+  		  # As escaping of certain symbols in path names had to be done manually in previous releases but is performed
+  		  # automatically now, a warning message is displayed when manual escaping is detected. This warning message
+  		  # should be removed in future.
+  		  for (symbol in c("\\(", "\\)", "\\[", "\\]")){
+  		    if (grepl(symbol, path_id, fixed = TRUE)){
+  		      warning("Escaping of the characters '(', ')', '[', and '[' should not be done manually!", immediate. = TRUE )
+  		      break
+  		    }
+  		  }
         searchValue <- path_id
         searchValue <- gsub('|', '\\|', searchValue, fixed = TRUE)
         searchValue <- gsub('&', '\\&', searchValue, fixed = TRUE)
+        searchValue <- gsub('(', '\\(', searchValue, fixed = TRUE)
+        searchValue <- gsub(')', '\\)', searchValue, fixed = TRUE)
+        searchValue <- gsub('[', '\\[', searchValue, fixed = TRUE)
+        searchValue <- gsub(']', '\\]', searchValue, fixed = TRUE)
         searchValue <- gsub('*', '.*', searchValue, fixed = TRUE)
         searchValue <- paste("^", searchValue, "$", sep="")
         searchPathes <- Table$Path
 
         indx <- grep(searchValue, searchPathes, perl = TRUE)                     
   		}
-    } else
-    {
-      indx <- 0
+    }
+    # If no parameter found, return a zero-lenght integer vector to match the behavior of which().
+    # This way, a not found parameter should be recognized by checking for (length(indx) == 0)
+    else{
+      indx <- integer(0);
     }
 	}
 	return(indx)	

--- a/src/code/findTableIndex.R
+++ b/src/code/findTableIndex.R
@@ -39,7 +39,7 @@ findTableIndex <- function(path_id = numeric(0), tableID = numeric(0), isReferen
   		  # should be removed in future.
   		  for (symbol in c("\\(", "\\)", "\\[", "\\]")){
   		    if (grepl(symbol, path_id, fixed = TRUE)){
-  		      warning("Escaping of the characters '(', ')', '[', and '[' should not be done manually!", immediate. = TRUE )
+  		      warning(paste(path_id, ": Escaping of the characters '(', ')', '[', and '[' in path names should not be done manually!"), immediate. = TRUE )
   		      break
   		    }
   		  }

--- a/tests/runit.getParameter.R
+++ b/tests/runit.getParameter.R
@@ -301,9 +301,39 @@ test.CheckParameterInSimulationNoneVariables <- function() {
 
   checkEquals(names(parameter), c("Value","Index"))
   checkEquals(dci_info$InputTab$AllParameters$Value[parameter$Index], parameter$Value)
+  
+  # Check that an exception is thrown when the parameter does not exist in the simulation
+  checkException(getParameter(path_id=0, DCI_Info = dci_info, options=options))
 
   options <- list(Type="variable")
   checkException(getParameter(path_id=113, DCI_Info = dci_info, options=options))
+}
+
+# Check if a parameter can be found by its given path name when no parameters were initialized explicitely.
+test.CheckParameterInSimulationNoneVariables_byPath <- function() {
+  dci_info <- standard_dci_info
+  options <- list(Type="current")
+  parameter <- getParameter(path_id = "black american girl|Organism|Muscle|Plasma|my Compound|concentration", DCI_Info = dci_info, options=options)
+  
+  checkEquals(names(parameter), c("Value","Index"))
+  checkEquals(dci_info$InputTab$AllParameters$Value[parameter$Index], parameter$Value)
+  
+  # Check that an exception is thrown when the parameter does not exist in the simulation
+  checkException(getParameter(path_id = "black american girl|Organism|nonExistent", DCI_Info = dci_info, options=options))
+  
+  options <- list(Type="variable")
+  checkException(getParameter(path_id = "black american girl|Organism|Muscle|Plasma|my Compound|concentration", DCI_Info = dci_info, options=options))
+}
+
+# Check if a parameter can be found by its given path name when no parameters were initialized explicitely
+# and the path name contains round brackets.
+test.CheckParameterInSimulationNoneVariables_byPathBrackets <- function() {
+  dci_info <- standard_dci_info
+  options <- list(Type="current")
+  parameter <- getParameter(path_id = "black american girl|Organism|pH (plasma)", DCI_Info = dci_info, options=options)
+  
+  checkEquals(names(parameter), c("Value","Index"))
+  checkEquals(dci_info$InputTab$AllParameters$Value[parameter$Index], parameter$Value)
 }
 
 test.CheckTableParameterValueTimeProfile <- function() {


### PR DESCRIPTION
- Add test for getParameter by path name
- Add test for getParameter with invalid path
- Add test for getParameter by path name containing brackets
- Automaticall escape "(", ")", "[", and "]"
- Add a warning if manual escaping of "(", ")", "[", or "]" is detected
- findTableIndex.R always returns "integer(0)" instead of "0" if the parameter could not be found