### PR TITLE
Fixes #36 New function request: getSolverWarnings()

### DIFF
--- a/src/code/getSolverWarnings.R
+++ b/src/code/getSolverWarnings.R
@@ -1,0 +1,33 @@
+#' Returns the list of warnings produced by the solver.
+#'
+#' @param DCI_Info 
+#'
+#' @return A list of warning strings. If no warnings were generated, an empty ist (character(0)) is returned.
+#' @export
+#'
+#' @examples
+getSolverWarnings <- function(DCI_Info = {}){
+  if (length(DCI_Info) == 0)
+  {
+    stop("Input 'DCI_Info' is missing.")
+  }
+  
+  #This will be the output list.
+  warnings = c();
+  #Get all warnings as a concatenated string.
+  warningsAsString = .Call('RDCI_Invoke', as.integer(DCI_Info$Handle), 'GetSolverWarnings', "");
+  
+  #If retrieving warnings failed for some reason, stop with an error
+  if (is.integer(warningsAsString) & warningsAsString == 0)
+  {
+    stop("Could not get solver warnings!")
+  }
+  
+  #Split into sub-strings, each sub-string representing a distinct warning.
+  warningsAsString = strsplit(warningsAsString, "¦", fixed = TRUE);
+  for (warning in warningsAsString){
+    warnings = c(warnings, warning);
+  }
+  
+  return (warnings)
+}

--- a/tests/runit.getSolverWarnings.R
+++ b/tests/runit.getSolverWarnings.R
@@ -1,0 +1,41 @@
+#require(RUnit, quietly=TRUE)
+#require(MoBiToolboxForR, quietly=TRUE)
+simModelXML <- "./tests/models/black american girl.xml"
+
+#Test for empty DCI_Info
+test.EmptyDCI_Info <- function() {
+  checkException(getSimulationResult(DCI_Info = {}))
+}
+
+#Test for invalid handle
+test.handleInvalid = function(){
+  DCI_Info = list();
+  DCI_Info$Handle = 0;
+  warning = getSolverWarnings(DCI_Info);
+  warningToExpect = paste("Component handle", DCI_Info$Handle, "is invalid!")
+  checkEquals(warning, warningToExpect);
+}
+
+test.noWarnings <- function() {
+  dci_info <- initSimulation(XML=simModelXML, whichInitParam="all");
+  warning = getSolverWarnings(DCI_Info = dci_info);
+  checkTrue(length(warning) == 0);
+  
+  dci_info = processSimulation(DCI_Info = dci_info);
+  warning = getSolverWarnings(DCI_Info = dci_info);
+  checkTrue(length(warning) == 0);
+}
+
+test.Warnings <- function() {
+  dci_info <- initSimulation(XML=simModelXML, whichInitParam="all", further_options = list(STOPONWARNINGS = FALSE))
+  dci_info = setParameter(9, "*|MxStep", DCI_Info = dci_info);
+  
+  #have to try-catch the processSimulation, as STOPONWARNINGS = FALSE seems not to work.
+  tryCatch(
+    {dci_info = processSimulation(DCI_Info = dci_info)},
+    error = function(err){
+    }
+  )
+  warning = getSolverWarnings(DCI_Info = dci_info);
+  checkTrue(is.character(warning) & length(warning) > 0);
+}


### PR DESCRIPTION
Add a function to get warnings produced by the solver as a list of strings.