### PR TITLE
Fixes #81 Feature request: Simulate to steady-state

### DIFF
--- a/src/code/getSpeciesSteadyState.R
+++ b/src/code/getSpeciesSteadyState.R
@@ -56,7 +56,7 @@ getSpeciesSteadyState = function(speciesNames = c("*"), steadyStateTime = 1000, 
       #Split the path of the name into container path and species name.
       fullPathParts = strsplit(existsSpeciesInitialValue(path_id = ID, options = list(Type = "readOnly"), DCI_Info = DCI_Info)$Path, "|", fixed = TRUE);
       containerPath_curr = fullPathParts[[1]][2];
-      for (i in 3 : length(fullPathParts[[1]]) - 1){
+      for (i in 3 : (length(fullPathParts[[1]]) - 1)){
         containerPath_curr = paste(containerPath_curr, fullPathParts[[1]][i], sep = "|");
       }
       moleculeName_curr = fullPathParts[[1]][length(fullPathParts[[1]])];

--- a/src/code/getSpeciesSteadyState.R
+++ b/src/code/getSpeciesSteadyState.R
@@ -1,0 +1,77 @@
+
+#' Get the steady-state values of species. The steady-state is considered to be the last value of the simulation with sufficiently
+#' long simulation time, i.e., where the rates of the processes do not change.
+#'
+#' @param speciesNames Vector of species names which steady-state values will be returned. By default, values of all species are returned. This also includes
+#' values of "state variable" parameters, as these are treated like species.
+#' @param steadyStateTime Simulation time (minites). Must be long enough for system to reach a steady-state. Default is 1000 minutes.
+#' @param ignoreIfFormula If "TRUE", species with initial values defined by formula are not included. Default is "TRUE".
+#' @param DCI_Info The DCI Info structure containing the DCI handle and all settings.
+#'
+#' @return A data frame with columns  "Container Path", "Molecule Name", "Is Present", "Value", "Units", "Scale Divisor", "Neg. Values Allowed".
+#' The Container Path does not include the name of the simulation.
+#' If not entries matching the criteria (speciesNames and ignoreIfFormula) could be generated, an emtpy data frame is returned (length = zero).
+#' @export
+#'
+#' @examples
+getSpeciesSteadyState = function(speciesNames = c("*"), steadyStateTime = 1000, ignoreIfFormula = TRUE, DCI_Info = {}){
+  #Perform initial input check
+  if (length(DCI_Info) == 0)
+  {
+    stop("No DCI_Info provided.")
+  }
+  if (steadyStateTime <= 0){
+    stop("steadyStateTime must be >0!");
+  }
+  
+  #Set simulation time to the steady-state value.
+  DCI_Info = setSimulationTime(timepoints = seq(0, steadyStateTime, length.out = 2), DCI_Info = DCI_Info);
+
+  DCI_Info = processSimulation(DCI_Info = DCI_Info);
+
+  #Create a list of the end values of the steady-state simulation.
+  containerPath = c();
+  moleculeName = c();
+  isPresent = c();
+  value = c();
+  units = c();
+  scaleDivisor = c();
+  negVals = c();
+  
+  #Get a vector of IDs of all species for which the steady-state values will be returned.
+  allIDs = c();
+  for (name in speciesNames){
+    allIDs = c(allIDs, existsSpeciesInitialValue(path_id = paste("*", name, sep = "|"), options = list(Type = "readOnly"), DCI_Info = DCI_Info)$ID);
+  }
+  allIDs = unique(allIDs);
+  
+  #Iterate through all species.
+  for (ID in allIDs){
+    isFormula = getSpeciesInitialValue(path_id = ID, list(Type = "readonly", Property = "IsFormula"), DCI_Info=DCI_Info)$Value;
+    #Add the species to the output list if it initial value is not defined by a formula OR formula defined species should not be ignored
+    if (!isFormula | !ignoreIfFormula){
+      #Split the path of the name into container path and species name.
+      fullPathParts = strsplit(existsSpeciesInitialValue(path_id = ID, options = list(Type = "readOnly"), DCI_Info = DCI_Info)$Path, "|", fixed = TRUE);
+      containerPath_curr = fullPathParts[[1]][2];
+      for (i in 3 : length(fullPathParts[[1]]) - 1){
+        containerPath_curr = paste(containerPath_curr, fullPathParts[[1]][i], sep = "|");
+      }
+      moleculeName_curr = fullPathParts[[1]][length(fullPathParts[[1]])];
+      
+      containerPath = c(containerPath, containerPath_curr);
+      moleculeName = c(moleculeName, moleculeName_curr);
+      isPresent = c(isPresent, TRUE);
+      value = c(value, getEndSimulationResult(path_id = ID, DCI_Info = DCI_Info)$Value);
+      units = c(units, getSpeciesInitialValue(path_id = ID, list(Type = "readonly", Property = "Unit"), DCI_Info=DCI_Info)$Value);
+      scaleDivisor = c(scaleDivisor, getSpeciesInitialValue(path_id = ID, list(Type = "readonly", Property = "ScaleFactor"), DCI_Info=DCI_Info)$Value);
+      negVals = c(negVals, "");
+    }
+  }
+  
+  speciesInitVals = data.frame(containerPath, moleculeName, isPresent, value, units, scaleDivisor, negVals);
+  if (length(speciesInitVals) > 0){
+    colnames(speciesInitVals) = c("Container Path", "Molecule Name", "Is Present", "Value", "Units", "Scale Divisor", "Neg. Values Allowed");
+  }
+  
+  return(speciesInitVals);
+}

--- a/src/code/getSpeciesSteadyState.R
+++ b/src/code/getSpeciesSteadyState.R
@@ -1,10 +1,9 @@
-
 #' Get the steady-state values of species. The steady-state is considered to be the last value of the simulation with sufficiently
-#' long simulation time, i.e., where the rates of the processes do not change.
+#' long simulation time, i.e., where the rates of the processes do not (significantly) change.
 #'
 #' @param speciesNames Vector of species names which steady-state values will be returned. By default, values of all species are returned. This also includes
 #' values of "state variable" parameters, as these are treated like species.
-#' @param steadyStateTime Simulation time (minites). Must be long enough for system to reach a steady-state. Default is 1000 minutes.
+#' @param steadyStateTime Simulation time (minites). Must be long enough for system to reach a steady-state.
 #' @param ignoreIfFormula If "TRUE", species with initial values defined by formula are not included. Default is "TRUE".
 #' @param DCI_Info The DCI Info structure containing the DCI handle and all settings.
 #'
@@ -25,15 +24,16 @@
 #'   #Initialize the given simulation with no variable parameters
 #' myDCI = initSimulation(modelPath, whichInitParam = "none");
 #' Get species steady-state
-#' initialValues = getSpeciesSteadyState(DCI_Info = myDCI, ignoreIfFormula = FALSE);
+#' initialValues = getSpeciesSteadyState(DCI_Info = myDCI, ignoreIfFormula = FALSE, steadyStateTime = 1000);
 #' Write the results into an excel file. (example with package "openxlsx"
 #' write.xlsx(list("Molecules" = (initialValues$moleculesSteadyState), "Parameters" = initialValues$parametersSteadyState), resultsXLS, colNames = TRUE)
-getSpeciesSteadyState = function(speciesNames = c("*"), steadyStateTime = 1000, ignoreIfFormula = TRUE, DCI_Info = {}){
+getSpeciesSteadyState = function(speciesNames = c("*"), steadyStateTime, ignoreIfFormula = TRUE, DCI_Info = {}){
   #Perform initial input check
   if (length(DCI_Info) == 0)
   {
     stop("No DCI_Info provided.")
   }
+  
   if (steadyStateTime <= 0){
     stop("steadyStateTime must be >0!");
   }

--- a/src/code/getSpeciesSteadyState.R
+++ b/src/code/getSpeciesSteadyState.R
@@ -48,8 +48,11 @@ getSpeciesSteadyState = function(speciesNames = c("*"), steadyStateTime = 1000, 
   #Iterate through all species.
   for (ID in allIDs){
     isFormula = getSpeciesInitialValue(path_id = ID, list(Type = "readonly", Property = "IsFormula"), DCI_Info=DCI_Info)$Value;
+    unit = getSpeciesInitialValue(path_id = ID, list(Type = "readonly", Property = "Unit"), DCI_Info=DCI_Info)$Value;
+    
     #Add the species to the output list if it initial value is not defined by a formula OR formula defined species should not be ignored
-    if (!isFormula | !ignoreIfFormula){
+    #AND the unit is µmol. Only import of the dimension "Amount" is supported by MoBi.
+    if ((unit == "µmol") && (!isFormula || !ignoreIfFormula)){
       #Split the path of the name into container path and species name.
       fullPathParts = strsplit(existsSpeciesInitialValue(path_id = ID, options = list(Type = "readOnly"), DCI_Info = DCI_Info)$Path, "|", fixed = TRUE);
       containerPath_curr = fullPathParts[[1]][2];
@@ -62,7 +65,7 @@ getSpeciesSteadyState = function(speciesNames = c("*"), steadyStateTime = 1000, 
       moleculeName = c(moleculeName, moleculeName_curr);
       isPresent = c(isPresent, TRUE);
       value = c(value, getEndSimulationResult(path_id = ID, DCI_Info = DCI_Info)$Value);
-      units = c(units, getSpeciesInitialValue(path_id = ID, list(Type = "readonly", Property = "Unit"), DCI_Info=DCI_Info)$Value);
+      units = c(units, unit);
       scaleDivisor = c(scaleDivisor, getSpeciesInitialValue(path_id = ID, list(Type = "readonly", Property = "ScaleFactor"), DCI_Info=DCI_Info)$Value);
       negVals = c(negVals, "");
     }

--- a/tests/runit.getSpeciesSteadyState.R
+++ b/tests/runit.getSpeciesSteadyState.R
@@ -3,7 +3,7 @@
 simModelXML <- "./tests/models/black american girl.xml"
 
 test.EmptyDCI_Info <- function() {
-  checkException(getSimulationResult(DCI_Info = {}))
+  checkException(getSpeciesSteadyState(DCI_Info = {}))
 }
 
 #Check behavior when no species provided. ATM, steady-state for all species should be provided.
@@ -13,41 +13,50 @@ test.emptySpecies = function(){
   allSpecies = existsSpeciesInitialValue(path_id = "*", DCI_Info = standard_dci_info);
   steadyState = getSpeciesSteadyState(DCI_Info = standard_dci_info);
   
-  checkEquals(length(allSpecies$Path), length(steadyState$`Container Path`));
+  
+  #The test is for the lenght of returned path - it should be identical to  the number of all species.
+  checkEquals(length(allSpecies$Path), length(steadyState$moleculesSteadyState$`Container Path`) + length(steadyState$parametersSteadyState$`Container Path`));
 }
 
 test.speciesExistent = function(){
   steadyState = getSpeciesSteadyState(speciesNames = c("my Compound"), DCI_Info = standard_dci_info);
-  checkTrue(length(steadyState) == 7);
+  #The test is for the number of returned columns - there should be 7 for "Container Path", "Molecule Name", "Is Present", "Value", "Scale Divisor", and "Neg. Values Allowed"
+  checkTrue(length(steadyState$moleculesSteadyState) == 7);
 }
 
 #If no provided species found in the simulation, an emtpy data frame is returned
 test.speciesNonExistent = function(){
   steadyState = getSpeciesSteadyState(speciesNames = c("doesNotExist"), DCI_Info = standard_dci_info);
-  checkEquals(length(steadyState), 0);
+  #The test is for the number of returned columns - there should be none as no species is found.
+  checkEquals(length(steadyState$moleculesSteadyState), 0);
 }
 
 test.speciesNonExistentExistent = function(){
   steadyState = getSpeciesSteadyState(speciesNames = c("doesNotExist", "my Compound"), DCI_Info = standard_dci_info);
-  checkTrue(length(steadyState) == 7);
+  #The test is for the number of returned columns - there should be 7 for "Container Path", "Molecule Name", "Is Present", "Value", "Scale Divisor", and "Neg. Values Allowed"
+  checkTrue(length(steadyState$moleculesSteadyState) == 7);
 }
 
 test.ignoreIfFormulaTrue = function(){
   #Formula flag should not affect non-formula species
   steadyState = getSpeciesSteadyState(speciesNames = c("my Compound"), ignoreIfFormula = TRUE, DCI_Info = standard_dci_info);
-  checkTrue(length(steadyState) == 7);
+  #The test is for the number of returned columns - there should be 7 for "Container Path", "Molecule Name", "Is Present", "Value", "Scale Divisor", and "Neg. Values Allowed"
+  checkTrue(length(steadyState$moleculesSteadyState) == 7);
   
   #Species with initial values defined by formula should be ignored
   steadyState = getSpeciesSteadyState(speciesNames = c("Liquid"), ignoreIfFormula = TRUE, DCI_Info = standard_dci_info);
-  checkEquals(length(steadyState), 0);
+  #The test is for the number of returned columns - there should be none as no species is found.
+  checkEquals(length(steadyState$parametersSteadyState), 0);
 }
 
 test.ignoreIfFormulaFalse = function(){
   #Formula flag should not affect non-formula species
   steadyState = getSpeciesSteadyState(speciesNames = c("my Compound"), ignoreIfFormula = FALSE, DCI_Info = standard_dci_info);
-  checkTrue(length(steadyState) == 7);
+  #The test is for the number of returned columns - there should be 7 for "Container Path", "Molecule Name", "Is Present", "Value", "Scale Divisor", and "Neg. Values Allowed"
+  checkTrue(length(steadyState$moleculesSteadyState) == 7);
   
   #Species with initial values defined by formula should be considered
   steadyState = getSpeciesSteadyState(speciesNames = c("Liquid"), ignoreIfFormula = FALSE, DCI_Info = standard_dci_info);
-  checkEquals(length(steadyState), 7);
+  #The test is for the number of returned columns - there should be 4 for "Container Path", "Parameter Name", "Value", and "Units"
+  checkEquals(length(steadyState$parametersSteadyState), 4);
 }

--- a/tests/runit.getSpeciesSteadyState.R
+++ b/tests/runit.getSpeciesSteadyState.R
@@ -11,52 +11,51 @@ test.EmptyDCI_Info <- function() {
 test.emptySpecies = function(){
   standard_dci_info <- initSimulation(XML=simModelXML, whichInitParam="none");
   allSpecies = existsSpeciesInitialValue(path_id = "*", DCI_Info = standard_dci_info);
-  steadyState = getSpeciesSteadyState(DCI_Info = standard_dci_info);
-  
+  steadyState = getSpeciesSteadyState(DCI_Info = standard_dci_info, steadyStateTime = 1000);
   
   #The test is for the lenght of returned path - it should be identical to  the number of all species.
   checkEquals(length(allSpecies$Path), length(steadyState$moleculesSteadyState$`Container Path`) + length(steadyState$parametersSteadyState$`Container Path`));
 }
 
 test.speciesExistent = function(){
-  steadyState = getSpeciesSteadyState(speciesNames = c("my Compound"), DCI_Info = standard_dci_info);
+  steadyState = getSpeciesSteadyState(speciesNames = c("my Compound"), DCI_Info = standard_dci_info, steadyStateTime = 1000);
   #The test is for the number of returned columns - there should be 7 for "Container Path", "Molecule Name", "Is Present", "Value", "Scale Divisor", and "Neg. Values Allowed"
   checkTrue(length(steadyState$moleculesSteadyState) == 7);
 }
 
 #If no provided species found in the simulation, an emtpy data frame is returned
 test.speciesNonExistent = function(){
-  steadyState = getSpeciesSteadyState(speciesNames = c("doesNotExist"), DCI_Info = standard_dci_info);
+  steadyState = getSpeciesSteadyState(speciesNames = c("doesNotExist"), DCI_Info = standard_dci_info, steadyStateTime = 1000);
   #The test is for the number of returned columns - there should be none as no species is found.
   checkEquals(length(steadyState$moleculesSteadyState), 0);
 }
 
 test.speciesNonExistentExistent = function(){
-  steadyState = getSpeciesSteadyState(speciesNames = c("doesNotExist", "my Compound"), DCI_Info = standard_dci_info);
+  steadyState = getSpeciesSteadyState(speciesNames = c("doesNotExist", "my Compound"), DCI_Info = standard_dci_info, steadyStateTime = 1000);
   #The test is for the number of returned columns - there should be 7 for "Container Path", "Molecule Name", "Is Present", "Value", "Scale Divisor", and "Neg. Values Allowed"
   checkTrue(length(steadyState$moleculesSteadyState) == 7);
 }
 
 test.ignoreIfFormulaTrue = function(){
   #Formula flag should not affect non-formula species
-  steadyState = getSpeciesSteadyState(speciesNames = c("my Compound"), ignoreIfFormula = TRUE, DCI_Info = standard_dci_info);
+  steadyState = getSpeciesSteadyState(speciesNames = c("my Compound"), ignoreIfFormula = TRUE, DCI_Info = standard_dci_info, steadyStateTime = 1000);
   #The test is for the number of returned columns - there should be 7 for "Container Path", "Molecule Name", "Is Present", "Value", "Scale Divisor", and "Neg. Values Allowed"
   checkTrue(length(steadyState$moleculesSteadyState) == 7);
   
   #Species with initial values defined by formula should be ignored
-  steadyState = getSpeciesSteadyState(speciesNames = c("Liquid"), ignoreIfFormula = TRUE, DCI_Info = standard_dci_info);
+  steadyState = getSpeciesSteadyState(speciesNames = c("Liquid"), ignoreIfFormula = TRUE, DCI_Info = standard_dci_info, steadyStateTime = 1000);
   #The test is for the number of returned columns - there should be none as no species is found.
   checkEquals(length(steadyState$parametersSteadyState), 0);
 }
 
 test.ignoreIfFormulaFalse = function(){
   #Formula flag should not affect non-formula species
-  steadyState = getSpeciesSteadyState(speciesNames = c("my Compound"), ignoreIfFormula = FALSE, DCI_Info = standard_dci_info);
+  steadyState = getSpeciesSteadyState(speciesNames = c("my Compound"), ignoreIfFormula = FALSE, DCI_Info = standard_dci_info, steadyStateTime = 1000);
   #The test is for the number of returned columns - there should be 7 for "Container Path", "Molecule Name", "Is Present", "Value", "Scale Divisor", and "Neg. Values Allowed"
   checkTrue(length(steadyState$moleculesSteadyState) == 7);
   
   #Species with initial values defined by formula should be considered
-  steadyState = getSpeciesSteadyState(speciesNames = c("Liquid"), ignoreIfFormula = FALSE, DCI_Info = standard_dci_info);
+  steadyState = getSpeciesSteadyState(speciesNames = c("Liquid"), ignoreIfFormula = FALSE, DCI_Info = standard_dci_info, steadyStateTime = 1000);
   #The test is for the number of returned columns - there should be 4 for "Container Path", "Parameter Name", "Value", and "Units"
   checkEquals(length(steadyState$parametersSteadyState), 4);
 }

--- a/tests/runit.getSpeciesSteadyState.R
+++ b/tests/runit.getSpeciesSteadyState.R
@@ -1,0 +1,53 @@
+#require(RUnit, quietly=TRUE)
+#require(MoBiToolboxForR, quietly=TRUE)
+simModelXML <- "./tests/models/black american girl.xml"
+
+test.EmptyDCI_Info <- function() {
+  checkException(getSimulationResult(DCI_Info = {}))
+}
+
+#Check behavior when no species provided. ATM, steady-state for all species should be provided.
+#However, the correct behavior would be only to return values of non-formula species.
+test.emptySpecies = function(){
+  standard_dci_info <- initSimulation(XML=simModelXML, whichInitParam="none");
+  allSpecies = existsSpeciesInitialValue(path_id = "*", DCI_Info = standard_dci_info);
+  steadyState = getSpeciesSteadyState(DCI_Info = standard_dci_info);
+  
+  checkEquals(length(allSpecies$Path), length(steadyState$`Container Path`));
+}
+
+test.speciesExistent = function(){
+  steadyState = getSpeciesSteadyState(speciesNames = c("my Compound"), DCI_Info = standard_dci_info);
+  checkTrue(length(steadyState) == 7);
+}
+
+#If no provided species found in the simulation, an emtpy data frame is returned
+test.speciesNonExistent = function(){
+  steadyState = getSpeciesSteadyState(speciesNames = c("doesNotExist"), DCI_Info = standard_dci_info);
+  checkEquals(length(steadyState), 0);
+}
+
+test.speciesNonExistentExistent = function(){
+  steadyState = getSpeciesSteadyState(speciesNames = c("doesNotExist", "my Compound"), DCI_Info = standard_dci_info);
+  checkTrue(length(steadyState) == 7);
+}
+
+test.ignoreIfFormulaTrue = function(){
+  #Formula flag should not affect non-formula species
+  steadyState = getSpeciesSteadyState(speciesNames = c("my Compound"), ignoreIfFormula = TRUE, DCI_Info = standard_dci_info);
+  checkTrue(length(steadyState) == 7);
+  
+  #Species with initial values defined by formula should be ignored
+  steadyState = getSpeciesSteadyState(speciesNames = c("Liquid"), ignoreIfFormula = TRUE, DCI_Info = standard_dci_info);
+  checkEquals(length(steadyState), 0);
+}
+
+test.ignoreIfFormulaFalse = function(){
+  #Formula flag should not affect non-formula species
+  steadyState = getSpeciesSteadyState(speciesNames = c("my Compound"), ignoreIfFormula = FALSE, DCI_Info = standard_dci_info);
+  checkTrue(length(steadyState) == 7);
+  
+  #Species with initial values defined by formula should be considered
+  steadyState = getSpeciesSteadyState(speciesNames = c("Liquid"), ignoreIfFormula = FALSE, DCI_Info = standard_dci_info);
+  checkEquals(length(steadyState), 7);
+}


### PR DESCRIPTION
Get the steady-state values of species. The steady-state is considered to be the last value of the simulation with sufficiently long simulation time, i.e., where the rates of the processes do not change.

Returns a list containing two data frames - moleculesSteadyState and parametersSteadyState. The data frame moleculesSteadyState contains columns "Container Path", "Molecule Name", "Is Present", "Value", "Units", "Scale Divisor", "Neg. Values Allowed".

The data frame parametersSteadyState. contains columns "Container Path", "Parameter Name", "Value", "Units".

All species with the unit "µmol" that are located within the "Organism"-structure are treated as molecules and stored in the moleculesSteadyState-data frame. That means that local state variable parameters with the dimension "Amount" are treated as molecules.

All species with units other then "µmol" OR the top container being not "Organism" are stored in the parametersSteadyState-data frame.

Example: the local state variable parameter "Organism|Fat|Intracellular|myReaction|ParamName" will be stored in the moleculesSteadyState-data frame.

The global parameter "myReaction|ParamName" will be stored in the parametersSteadyState-data frame.
The Container Path does not include the name of the simulation.

If no entries matching the criteria (speciesNames and ignoreIfFormula) could be generated, an emtpy data frame is returned (length = zero).