### PR TITLE
Fixes #37 Compare simulations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ setup/deploy/
 MoBiToolBoxForR/
 MoBiToolBoxForR_*
 .Rproj.user
+/tests/Protocol.html

--- a/src/code/compareSimulations.R
+++ b/src/code/compareSimulations.R
@@ -1,0 +1,498 @@
+#objectType can be "Parameter", "Species", or "Observer"
+compareStructures = function(objectType, DCI_Info1, DCI_Info2, simName1, simName2, numTolerance, ignoreFormula){
+  #This list holds information about the differences between simulations objects.
+  objects_diff = list();
+  
+  #Get existence information about all objects depending on their type.
+  if(objectType == "Parameter"){
+    allObjects1 = existsParameter(path_id = "*", options = list(Type = "readonly"), DCI_Info = DCI_Info1);
+    allObjects2 = existsParameter(path_id = "*", options = list(Type = "readonly"), DCI_Info = DCI_Info2);
+  }
+  if(objectType == "Species"){
+    allObjects1 = existsSpeciesInitialValue(path_id = "*", options = list(Type = "readonly"), DCI_Info = DCI_Info1);
+    allObjects2 = existsSpeciesInitialValue(path_id = "*", options = list(Type = "readonly"), DCI_Info = DCI_Info2);
+  }
+  if(objectType == "Observer"){
+    allObjects1 = existsObserver(path_id = "*", DCI_Info = DCI_Info1);
+    allObjects2 = existsObserver(path_id = "*", DCI_Info = DCI_Info2);
+  }
+  
+  objectsPaths = c();
+  existanceInFirst = c();
+  existanceInSecond = c();
+  valuesFirst = c();
+  valuesSecond = c();
+  formulaFlagsFirst = c();
+  formulaFlagsSecond = c();
+  formulaStringsFirst = c();
+  formulaStringsSecond = c();
+  
+  #Mark indices in the second simulation which have been compared
+  idxComparedInSecond = c();
+  
+  #Iterate through all objects from the first simulation and compare them to the objects from the second simulation.
+  for (firstIdx in allObjects1$Index){
+    #Flag determining whether the objects are identical in both simulations.
+    identical = TRUE;
+    #Flag determining whether the object exists in the first simulation
+    existsInFirst = TRUE;
+    #Get the path of the entry.
+    objectInfo = splitSimNameFromPath(allObjects1$Path[firstIdx]);
+    objectPath = objectInfo$Path;
+    #Some parameters (e.g., 'AbsTol') do not require the name of the simulation as path prefix.
+    #To correctly construct the path in the other simulation, mark whether addition of simulation name is required.
+    pathIncludesSimName = TRUE;
+    if (! (nchar(objectInfo$SimName) > 0) ){
+      pathIncludesSimName = FALSE;
+    }
+    #ID of the object in the first simulation
+    idFirst = allObjects1$ID[firstIdx];
+    
+    #Value of the object in the first simulation
+    firstValue = NaN;
+    if(objectType == "Parameter"){
+      firstValue = getParameter(path_id = idFirst, options = list(Type = "current"), DCI_Info = DCI_Info1)$Value;
+    }
+    if(objectType == "Species"){
+      firstValue = getSpeciesInitialValue(path_id = idFirst, options = list(Type = "current"), DCI_Info = DCI_Info1)$Value;
+    }
+    
+    #Is the object defined by a formula in the first simulation?
+    isFormulaInFirst = TRUE;
+    if(objectType == "Parameter"){
+      isFormulaInFirst = as.logical(getParameter(path_id = idFirst, options = list(Type = "current", Property = "IsFormula"), DCI_Info = DCI_Info1)$Value);
+    }
+    if(objectType == "Species"){
+      isFormulaInFirst = as.logical(getSpeciesInitialValue(path_id = idFirst, options = list(Type = "current", Property = "IsFormula"), DCI_Info = DCI_Info1)$Value);
+    }
+    #Formula string (empty if the object is non-formula)
+    formulaStringFirst = "";
+    if(isFormulaInFirst){
+      if(objectType == "Parameter"){
+        formulaStringFirst = getParameter(path_id = idFirst, options = list(Type = "current", Property = "Formula"), DCI_Info = DCI_Info1)$Value;
+      }
+      if(objectType == "Species"){
+        formulaStringFirst = getSpeciesInitialValue(path_id = idFirst, options = list(Type = "current", Property = "Formula"), DCI_Info = DCI_Info1)$Value;
+      }
+      if(objectType == "Observer"){
+        formulaStringFirst = getObserverFormula(path_id = idFirst, DCI_Info = DCI_Info1)$Value;
+      }
+    }
+    
+    #Find the entry with the same path in the second simulation.
+    simNameForSearch = "";
+    if (pathIncludesSimName){
+      simNameForSearch = simName2;
+    }
+    if(objectType == "Parameter"){
+      secondObject = existsParameter(path_id = paste(simNameForSearch, objectPath, sep = "|"), options = list(Type = "readonly"), DCI_Info = DCI_Info2);
+    }
+    if(objectType == "Species"){
+      secondObject = existsSpeciesInitialValue(path_id = paste(simNameForSearch, objectPath, sep = "|"), options = list(Type = "readonly"), DCI_Info = DCI_Info2);
+    }
+    if(objectType == "Observer"){
+      secondObject = existsObserver(path_id = paste(simNameForSearch, objectPath, sep = "|"), DCI_Info = DCI_Info2);
+    }
+    if((existsInSecond = secondObject$isExisting)){
+      #ID of the object in the second simulation
+      idSecond = allObjects2$ID[secondObject$Index];
+      #Value of the object in the second simulation
+      secondValue = NaN;
+      if(objectType == "Parameter"){
+        secondValue = getParameter(path_id = idSecond, options = list(Type = "current"), DCI_Info = DCI_Info2)$Value;
+      }
+      if(objectType == "Species"){
+        secondValue = getSpeciesInitialValue(path_id = idSecond, options = list(Type = "current"), DCI_Info = DCI_Info2)$Value;
+      }
+      #Is the object defined by a formula in the second simulation?
+      isFormulaInSecond = TRUE;
+      if(objectType == "Parameter"){
+        isFormulaInSecond = as.logical(getParameter(path_id = idSecond, options = list(Type = "current", Property = "IsFormula"), DCI_Info = DCI_Info2)$Value);
+      }
+      if(objectType == "Species"){
+        isFormulaInSecond = as.logical(getSpeciesInitialValue(path_id = idSecond, options = list(Type = "current", Property = "IsFormula"), DCI_Info = DCI_Info2)$Value);
+      }
+      #Formula string (empty if the object is non-formula)
+      formulaStringSecond = "";
+      if(isFormulaInSecond){
+        if(objectType == "Parameter"){
+          formulaStringSecond = getParameter(path_id = idSecond, options = list(Type = "current", Property = "Formula"), DCI_Info = DCI_Info2)$Value;
+        }
+        if(objectType == "Species"){
+          formulaStringSecond = getSpeciesInitialValue(path_id = idSecond, options = list(Type = "current", Property = "Formula"), DCI_Info = DCI_Info2)$Value;
+        }
+        if(objectType == "Observer"){
+          formulaStringSecond = getObserverFormula(path_id = idSecond, DCI_Info = DCI_Info2)$Value;
+        }
+      }
+      
+      #Compare objects
+      identical = (isTRUE(all.equal.numeric(firstValue, secondValue, tolerance = numTolerance)));
+      if (!ignoreFormula){
+        identical = (identical & (isFormulaInFirst == isFormulaInSecond) & isTRUE(all.equal.character(formulaStringFirst, formulaStringSecond)));
+      }
+      #Mark the object idnex as compared.
+      idxComparedInSecond = c(idxComparedInSecond, secondObject$Index);
+    }
+    #Object is not in second simulation
+    else{
+      identical = FALSE;
+      secondValue = NaN;
+      isFormulaInSecond = NaN;
+      formulaStringSecond = "";
+    }
+    
+    #If the objects are not identical, create an entry in differences-list.
+    if( !identical ){
+      objectsPaths = c(objectsPaths, objectPath);
+      existanceInFirst = c(existanceInFirst, existsInFirst);
+      existanceInSecond = c(existanceInSecond, existsInSecond);
+      valuesFirst = c(valuesFirst, firstValue);
+      valuesSecond = c(valuesSecond, secondValue);
+      formulaFlagsFirst = c(formulaFlagsFirst, isFormulaInFirst);
+      formulaFlagsSecond = c(formulaFlagsSecond, isFormulaInSecond);
+      formulaStringsFirst = c(formulaStringsFirst, formulaStringFirst);
+      formulaStringsSecond = c(formulaStringsSecond, formulaStringSecond);
+    }
+  }
+  
+  #Iterate through objects from the second simulation that have not been compared and compare them to the objects from the first simulation.
+  for (secondIdx in setdiff(allObjects2$Index, idxComparedInSecond)){
+    #Flag determining whether the objects are identical in both simulations.
+    identical = TRUE;
+    #Flag determining whether the object exists in the second simulation
+    existsInSecond = TRUE;
+    #Get the path of the object
+    objectInfo = splitSimNameFromPath(allObjects1$Path[firstIdx]);
+    objectPath = objectInfo$Path;
+    #Some parameters (e.g., 'AbsTol') do not require the name of the simulation as path prefix.
+    #To correctly construct the path in the other simulation, mark whether addition of simulation name is required.
+    pathIncludesSimName = TRUE;
+    if (! (nchar(objectInfo$SimName) > 0) ){
+      pathIncludesSimName = FALSE;
+    }
+    #ID of the object in the second simulation
+    idSecond = allObjects2$ID[secondIdx];
+    
+    #Value of the object in the second simulation
+    secondValue = NaN;
+    if(objectType == "Parameter"){
+      secondValue = getParameter(path_id = idSecond, options = list(Type = "current"), DCI_Info = DCI_Info2)$Value;
+    }
+    if(objectType == "Species"){
+      secondValue = getSpeciesInitialValue(path_id = idSecond, options = list(Type = "current"), DCI_Info = DCI_Info2)$Value;
+    }
+    
+    #Is the object defined by a formula in the second simulation?
+    isFormulaInSecond = TRUE;
+    if(objectType == "Parameter"){
+      isFormulaInSecond = as.logical(getParameter(path_id = idSecond, options = list(Type = "current", Property = "IsFormula"), DCI_Info = DCI_Info2)$Value);
+    }
+    if(objectType == "Species"){
+      isFormulaInSecond = as.logical(getSpeciesInitialValue(path_id = idSecond, options = list(Type = "current", Property = "IsFormula"), DCI_Info = DCI_Info2)$Value);
+    }
+    #Formula string (empty if the object is non-formula)
+    formulaStringSecond = "";
+    if(isFormulaInSecond){
+      if(objectType == "Parameter"){
+        formulaStringSecond = getParameter(path_id = idSecond, options = list(Type = "current", Property = "Formula"), DCI_Info = DCI_Info2)$Value;
+      }
+      if(objectType == "Species"){
+        formulaStringSecond = getSpeciesInitialValue(path_id = idSecond, options = list(Type = "current", Property = "Formula"), DCI_Info = DCI_Info2)$Value;
+      }
+      if(objectType == "Observer"){
+        formulaStringSecond = getObserverFormula(path_id = idSecond, DCI_Info = DCI_Info2)$Value;
+      }
+    }
+    
+    #Find the object with the same path in the first simulation.
+    simNameForSearch = "";
+    if (pathIncludesSimName){
+      simNameForSearch = simName1;
+    }
+    if(objectType == "Parameter"){
+      firstObject = existsParameter(path_id = paste(simNameForSearch, objectPath, sep = "|"), options = list(Type = "readonly"), DCI_Info = DCI_Info1);
+    }
+    if(objectType == "Species"){
+      firstObject = existsSpeciesInitialValue(path_id = paste(simNameForSearch, objectPath, sep = "|"), options = list(Type = "readonly"), DCI_Info = DCI_Info1);
+    }
+    if(objectType == "Observer"){
+      firstObject = existsObserver(path_id = paste(simNameForSearch, objectPath, sep = "|"), DCI_Info = DCI_Info1);
+    }
+    
+    if((existsInFirst = firstObject$isExisting)){
+      #ID of the object in the first simulation
+      idFirst = allObjects1$ID[firstObject$Index];
+      #Value of the object in the first simulation
+      firstValue = NaN;
+      if(objectType == "Parameter"){
+        firstValue = getParameter(path_id = idFirst, options = list(Type = "current"), DCI_Info = DCI_Info1)$Value;
+      }
+      if(objectType == "Species"){
+        firstValue = getSpeciesInitialValue(path_id = idFirst, options = list(Type = "current"), DCI_Info = DCI_Info1)$Value;
+      }
+      
+      #Is the object defined by a formula in the first simulation?
+      isFormulaInFirst = TRUE;
+      if(objectType == "Parameter"){
+        isFormulaInFirst = as.logical(getParameter(path_id = idFirst, options = list(Type = "current", Property = "IsFormula"), DCI_Info = DCI_Info1)$Value);
+      }
+      if(objectType == "Species"){
+        isFormulaInFirst = as.logical(getSpeciesInitialValue(path_id = idFirst, options = list(Type = "current", Property = "IsFormula"), DCI_Info = DCI_Info1)$Value);
+      }
+      #Formula string (empty if parameter is non-formula)
+      formulaStringFirst = "";
+      if(isFormulaInFirst){
+        if(objectType == "Parameter"){
+          formulaStringFirst = getParameter(path_id = idFirst, options = list(Type = "current", Property = "Formula"), DCI_Info = DCI_Info1)$Value;
+        }
+        if(objectType == "Species"){
+          formulaStringFirst = getSpeciesInitialValue(path_id = idFirst, options = list(Type = "current", Property = "Formula"), DCI_Info = DCI_Info1)$Value;
+        }
+        if(objectType == "Observer"){
+          formulaStringFirst = getObserverFormula(path_id = idFirst, DCI_Info = DCI_Info1)$Value;
+        }
+      }
+      
+      #Compare the objects
+      identical = (isTRUE(all.equal.numeric(firstValue, secondValue, tolerance = numTolerance)));
+      if (!ignoreFormula){
+        identical = (identical & (isFormulaInFirst == isFormulaInSecond) & isTRUE(all.equal.character(formulaStringFirst, formulaStringSecond)));
+      }
+    }
+    #Object is not in first simulation
+    else{
+      identical = FALSE;
+      firstValue = NaN;
+      isFormulaInFirst = NaN;
+      formulaStringFirst = "";
+    }
+    
+    #If the objects are not identical, create an entry in differences-list.
+    if( !identical ){
+      objectsPaths = c(objectsPaths, objectPath);
+      existanceInFirst = c(existanceInFirst, existsInFirst);
+      existanceInSecond = c(existanceInSecond, existsInSecond);
+      valuesFirst = c(valuesFirst, firstValue);
+      valuesSecond = c(valuesSecond, secondValue);
+      formulaFlagsFirst = c(formulaFlagsFirst, isFormulaInFirst);
+      formulaFlagsSecond = c(formulaFlagsSecond, isFormulaInSecond);
+      formulaStringsFirst = c(formulaStringsFirst, formulaStringFirst);
+      formulaStringsSecond = c(formulaStringsSecond, formulaStringSecond);
+    }
+  }
+  
+  objects_diff$Path = objectsPaths;
+  objects_diff$isExistingFirst = existanceInFirst;
+  objects_diff$isExistingSecond = existanceInSecond;
+  objects_diff$ValueFirst = valuesFirst;
+  objects_diff$ValueSecond = valuesSecond;
+  objects_diff$IsFormulaFirst = formulaFlagsFirst;
+  objects_diff$IsFormulaSecond = formulaFlagsSecond;
+  objects_diff$FormulaFirst = formulaStringsFirst;
+  objects_diff$FormulaSecond = formulaStringsSecond;
+  return(objects_diff);
+}
+
+compareSimulationTime = function(simTime1, simTime2){
+  identical = TRUE;
+  #Compare time pattern by size and element-wise
+  if ( !(length(simTime1$Time) == (length(simTime2$Time))) | !isTRUE(all.equal.numeric(simTime1$Time, simTime2$Time)) ){
+    identical = FALSE;
+  }
+  return(identical);
+}
+
+writeToCSV = function(CSV_path, results){
+  dirname <- dirname(CSV_path)
+  if (!file.exists(dirname)) {
+    dir.create(dirname, recursive=TRUE)
+  }
+  outString = "Simulation names";
+  outString = c(outString, paste(results$SimNames[1], results$SimNames[2], sep = "\t"));
+  
+  outString = c(outString, "Parameter differences:");
+  outString = c(outString, paste("Path", "Exists in first", "Exists in second", "Value in first", "Value in second", "Is formula in first", "Is formula in second", "Formula string in first", "Formula string in second", sep = "\t"));
+  if (length(results$Params_diff) > 0){
+    for (i in 1 : length(results$Params_diff$Path)){
+      outString = c(outString, paste(
+        results$Params_diff$Path[i],
+        results$Params_diff$isExistingFirst[i],
+        results$Params_diff$isExistingSecond[i],
+        results$Params_diff$ValueFirst[i],
+        results$Params_diff$ValueSecond[i],
+        results$Params_diff$IsFormulaFirst[i],
+        results$Params_diff$IsFormulaSecond[i],
+        results$Params_diff$FormulaFirst[i],
+        results$Params_diff$FormulaSecond[i],
+        sep = "\t"));
+    }
+  }
+  
+  outString = c(outString, "Species differences:");
+  outString = c(outString, paste("Path", "Exists in first", "Exists in second", "Value in first", "Value in second", "Is formula in first", "Is formula in second", "Formula string in first", "Formula string in second", sep = "\t"));
+  if (length(results$Species_diff) > 0){
+    for (i in 1 : length(results$Species_diff$Path)){
+      outString = c(outString, paste(
+        results$Species_diff$Path[i],
+        results$Species_diff$isExistingFirst[i],
+        results$Species_diff$isExistingSecond[i],
+        results$Species_diff$ValueFirst[i],
+        results$Species_diff$ValueSecond[i],
+        results$Species_diff$IsFormulaFirst[i],
+        results$Species_diff$IsFormulaSecond[i],
+        results$Species_diff$FormulaFirst[i],
+        results$Species_diff$FormulaSecond[i],
+        sep = "\t"));
+    }
+  }
+  
+  outString = c(outString, "Observer differences:");
+  outString = c(outString, paste("Path", "Exists in first", "Exists in second", "Value in first", "Value in second", "Is formula in first", "Is formula in second", "Formula string in first", "Formula string in second", sep = "\t"));
+  if (length(results$Observer_diff) > 0){
+    for (i in 1 : length(results$Observer_diff$Path)){
+      outString = c(outString, paste(
+        results$Observer_diff$Path[i],
+        results$Observer_diff$isExistingFirst[i],
+        results$Observer_diff$isExistingSecond[i],
+        results$Observer_diff$ValueFirst[i],
+        results$Observer_diff$ValueSecond[i],
+        results$Observer_diff$IsFormulaFirst[i],
+        results$Observer_diff$IsFormulaSecond[i],
+        results$Observer_diff$FormulaFirst[i],
+        results$Observer_diff$FormulaSecond[i],
+        sep = "\t"));
+    }
+  }
+  outString = c(outString, paste0("Time pattern identical\t", results$TimeIdentical));
+  
+  
+  write.table(x = outString, file = resultsCSV_path, row.names = FALSE, col.names = FALSE, dec = ",");
+}
+
+#' Compares two simulations for differences.
+#' Comparison is done for:
+#' parameter existence, value and formula, 
+#' species initial value existence, value and formula, 
+#' observer existence and formula,
+#' time pattern identity.
+#'
+#' @param DCI_Info1 DCI_Info of the first simulation
+#' @param DCI_Info2 DCI_Info of the second simulation
+#' @param numTolerance Maximal numeric deviation which is accepted as equal. Default value is 1e-8.
+#' @param resultsCSV_path A path to a file where the results of the comparison are writen to. If emtpy, no output into a file is performed. If a file with the given path exists, it will be 
+#' overwritten; otherwise, a new file is created. Emtpy by default.
+#' @param ignoreFormula If true, only values of parameters or molecule start values are compared. If false, formula strings are compared. FALSE by default.
+#'
+#' @return
+#' A list containing the lists 'SimNames', 'Params_diff', 'Species_diff', 'Observer_diff', and a boolean 'TimeIdentical'.
+#' 'SimNames' contains the names of the compared simulations.
+#' 'Params_diff', 'Species_diff' and 'Observer_diff' contain columns 'Path' with the path of the compared object,
+#' 'isExistingFirst' boolean value whether the object exists in the first simulation,
+#' 'isExistingSecond' boolean value whether the object  exists in the second simulation,
+#' 'ValueFirst' value of the object in the first simulation,
+#' 'ValueSecond' value of the object in the second simulation,
+#' 'IsFormulaFirst' boolean value whether the object is defined by a formula in the first simulation,
+#' 'IsFormulaSecond' boolean value whether the object is defined by a formula in the second simulation,
+#' 'FormulaFirst' string reprentation of the parameter value in the first simulation (empty if parameter is not defined by a formula),
+#' 'FormulaSecond' string reprentation of the parameter value in the second simulation (empty if parameter is not defined by a formula).
+#' 'TimeIdentical' is a boolean defining whether the time-patterns are equal in both simulations.
+#' If DCI_Info1 and DCI_Info2 have the same handle-ID, identity of the simulations is assumed without comparison.
+#' If no differences are found, an empty list is returned for the corresponding entry (parameters, species, observers).
+#' @export
+#'
+#' @examples
+#' dci_info1 = initSimulation(simModelXML1, whichInitParam = "none");
+#' dci_info2_diff = initSimulation(simModelXML1, whichInitParam = "all");
+#' diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info2_diff, ignoreFormula = TRUE, resultsCSV_path = "C:/diffs.csv");
+#' 
+compareSimulations = function(DCI_Info1 = {}, DCI_Info2 = {}, numTolerance = 1e-8, resultsCSV_path = "", ignoreFormula = FALSE){
+  #Check for missing DCI_Info
+  if (length(DCI_Info1) == 0 | length(DCI_Info2) == 0)
+  {
+    stop("One of the inputs 'DCI_Info' is missing.")
+  }
+  #Numerical tolerance sanity check
+  if (numTolerance < 0){
+    stop(paste("numTolerance must be positive, value", numTolerance, "is invalid!"));
+  }
+  #ignoreFormula non-boolean
+  if (!is.logical(ignoreFormula)){
+    stop(paste("ignoreFormula must be a boolean, value", ignoreFormula, "is invalid! Use TRUE of FALSE."));
+  }
+  
+  #list of the results - this is the output of the function.
+  results = list();
+  
+  #Try to get simulation names. Use any parameter path.
+  if (length(DCI_Info1$ReferenceTab$AllParameters$Path) > 0){
+    anyParam_1_path = DCI_Info1$ReferenceTab$AllParameters$Path[1];
+    simName1 = splitSimNameFromPath(anyParam_1_path)$SimName;
+    
+    anyParam_1_path = "";
+  }
+  else{
+    simName1 = "Not available";
+  }
+  #Name of the second simulation
+  if (length(DCI_Info2$ReferenceTab$AllParameters$Path) > 0){
+    anyParam_2_path = DCI_Info2$ReferenceTab$AllParameters$Path[1];
+    simName2 = splitSimNameFromPath(anyParam_2_path)$SimName;
+    
+    anyParam_2_path = "";
+  }
+  else{
+    simName2 = "Not available";
+  }
+  #Store simulation names into the output.
+  results$SimNames = c(simName1, simName2);
+  
+  #If same DCI is compared, return no differences without comparison
+  if (DCI_Info1$Handle == DCI_Info2$Handle){
+    objects_diff = list();
+    objects_diff$Path = c();
+    objects_diff$isExistingFirst = c();
+    objects_diff$isExistingSecond = c();
+    objects_diff$ValueFirst = c();
+    objects_diff$ValueSecond = c();
+    objects_diff$IsFormulaFirst = c();
+    objects_diff$IsFormulaSecond = c();
+    objects_diff$FormulaFrist = c();
+    objects_diff$FormulaSecond = c();
+    results$Params_diff = objects_diff;
+    results$Species_diff = objects_diff;
+    results$Observer_diff = objects_diff;
+    results$TimeIdentical = TRUE;
+    
+    #If a path to output file a specified, write the results into a CSV-file.
+    if (!resultsCSV_path == "")
+    {
+      writeToCSV(CSV_path = resultsCSV_path, results = results);
+    }
+    return(results)
+  }
+  
+  #Compare parameters, species, and observers.
+  params_diff = compareStructures("Parameter", DCI_Info1, DCI_Info2, numTolerance = numTolerance, simName1 = simName1, simName2 = simName2, ignoreFormula = ignoreFormula);
+  species_diff = compareStructures("Species", DCI_Info1, DCI_Info2, numTolerance = numTolerance, simName1 = simName1, simName2 = simName2, ignoreFormula = ignoreFormula);
+  observer_diff = compareStructures("Observer", DCI_Info1, DCI_Info2,numTolerance = numTolerance, simName1 = simName1, simName2 = simName2, ignoreFormula = ignoreFormula);
+  
+  #Compare simulation time
+  simTime1 = getSimulationTime(DCI_Info = DCI_Info1);
+  simTime2 = getSimulationTime(DCI_Info = DCI_Info2);
+  timeIdentical = compareSimulationTime(simTime1, simTime2);
+  
+  #Store parameter differences
+  results$Params_diff = params_diff;
+  results$Species_diff = species_diff;
+  results$Observer_diff = observer_diff;
+  results$TimeIdentical = timeIdentical;
+  
+  #If a path to output file a specified, write the results into a CSV-file.
+  if (!resultsCSV_path == "")
+  {
+    writeToCSV(CSV_path = resultsCSV_path, results = results);
+  }
+  
+  return(results)
+}

--- a/src/code/compareSimulations.R
+++ b/src/code/compareSimulations.R
@@ -1,37 +1,81 @@
-#objectType can be "Parameter", "Species", or "Observer"
-compareStructures = function(objectType, DCI_Info1, DCI_Info2, simName1, simName2, numTolerance, ignoreFormula){
+getObjectProperty = function(objectType, path_id, DCI_Info, property){
+  switch(objectType,
+         Parameter = {
+           value = getParameter(path_id = path_id, options = list(Type = "current", Property = property), DCI_Info = DCI_Info)$Value;
+         },
+         Species = {
+           if (property == "Value"){
+             property = "InitialValue";
+           }
+           value = getSpeciesInitialValue(path_id = path_id, options = list(Type = "current", Property = property), DCI_Info = DCI_Info)$Value;
+         },
+         Observer = {
+           #No value is returned for observers.
+           if (property == "Value"){
+             value = NaN;
+           }
+           if (property == "IsFormula"){
+             value = TRUE;
+           }
+           if (property == "Formula"){
+             value = getObserverFormula(path_id = path_id, DCI_Info = DCI_Info)$Value;
+           }
+         },
+         stop(paste0("getObjectValue: Unknown objectType passed: ", objectType, "; accepted values are 'Parameter', 'Species', 'Observer'"))
+  );
+  return(value);
+}
+
+getObjectExistance = function(objectType, path_id, DCI_Info){
+  switch(objectType,
+         Parameter = {
+           value = existsParameter(path_id = path_id, options = list(Type = "readonly"), DCI_Info = DCI_Info);
+         },
+         Species = {
+           value = existsSpeciesInitialValue(path_id = path_id, options = list(Type = "readonly"), DCI_Info = DCI_Info);
+         },
+         Observer = {
+           value = existsObserver(path_id = path_id, DCI_Info = DCI_Info);
+         },
+         stop(paste0("getObjectExistance: Unknown objectType passed: ", objectType, "; accepted values are 'Parameter', 'Species', 'Observer'"))
+  );
+  return(value);
+}
+
+compareObjects = function(DCI_Info1, DCI_Info2, options, excludeIdx = c()){
+  if (length(options) == 0){
+    stop("compareObjects: options is not provided!");
+  }
+  
   #This list holds information about the differences between simulations objects.
   objects_diff = list();
+  #Path of the object in the simulation.
+  objects_diff$Path = c();
+  #Does the object exist in the first simulation?
+  objects_diff$isExistingFirst = c();
+  #Does the object exist in the second simulation?
+  objects_diff$isExistingSecond = c();
+  #Numerical value of the object in the first simulation.
+  objects_diff$ValueFirst = c();
+  #Numerical value of the object in the second simulation.
+  objects_diff$ValueSecond = c();
+  #Is the objects value defined by a formula in the first simulation?
+  objects_diff$IsFormulaFirst = c();
+  #Is the objects value defined by a formula in the second simulation?
+  objects_diff$IsFormulaSecond = c();
+  #Formula string defining the value of the object in the first simulation. Empty if no formula used.
+  objects_diff$FormulaFirst = c();
+  #Formula string defining the value of the object in the second simulation. Empty if no formula used.
+  objects_diff$FormulaSecond = c();
   
-  #Get existence information about all objects depending on their type.
-  if(objectType == "Parameter"){
-    allObjects1 = existsParameter(path_id = "*", options = list(Type = "readonly"), DCI_Info = DCI_Info1);
-    allObjects2 = existsParameter(path_id = "*", options = list(Type = "readonly"), DCI_Info = DCI_Info2);
-  }
-  if(objectType == "Species"){
-    allObjects1 = existsSpeciesInitialValue(path_id = "*", options = list(Type = "readonly"), DCI_Info = DCI_Info1);
-    allObjects2 = existsSpeciesInitialValue(path_id = "*", options = list(Type = "readonly"), DCI_Info = DCI_Info2);
-  }
-  if(objectType == "Observer"){
-    allObjects1 = existsObserver(path_id = "*", DCI_Info = DCI_Info1);
-    allObjects2 = existsObserver(path_id = "*", DCI_Info = DCI_Info2);
-  }
+  #Get existence information about all objects.
+  allObjects1 = getObjectExistance(objectType = options$objectType, path_id = "*", DCI_Info = DCI_Info1);
+  allObjects2 = getObjectExistance(objectType = options$objectType, path_id = "*", DCI_Info = DCI_Info2);
   
-  objectsPaths = c();
-  existanceInFirst = c();
-  existanceInSecond = c();
-  valuesFirst = c();
-  valuesSecond = c();
-  formulaFlagsFirst = c();
-  formulaFlagsSecond = c();
-  formulaStringsFirst = c();
-  formulaStringsSecond = c();
-  
-  #Mark indices in the second simulation which have been compared
+  #Mark indices of the objects that have been compared in the second simulation.
   idxComparedInSecond = c();
-  
   #Iterate through all objects from the first simulation and compare them to the objects from the second simulation.
-  for (firstIdx in allObjects1$Index){
+  for (firstIdx in setdiff(allObjects1$Index, excludeIdx)){
     #Flag determining whether the objects are identical in both simulations.
     identical = TRUE;
     #Flag determining whether the object exists in the first simulation
@@ -49,89 +93,46 @@ compareStructures = function(objectType, DCI_Info1, DCI_Info2, simName1, simName
     idFirst = allObjects1$ID[firstIdx];
     
     #Value of the object in the first simulation
-    firstValue = NaN;
-    if(objectType == "Parameter"){
-      firstValue = getParameter(path_id = idFirst, options = list(Type = "current"), DCI_Info = DCI_Info1)$Value;
-    }
-    if(objectType == "Species"){
-      firstValue = getSpeciesInitialValue(path_id = idFirst, options = list(Type = "current"), DCI_Info = DCI_Info1)$Value;
-    }
+    firstValue = getObjectProperty(objectType = options$objectType, path_id = idFirst, DCI_Info = DCI_Info1, property = "Value");
     
     #Is the object defined by a formula in the first simulation?
-    isFormulaInFirst = TRUE;
-    if(objectType == "Parameter"){
-      isFormulaInFirst = as.logical(getParameter(path_id = idFirst, options = list(Type = "current", Property = "IsFormula"), DCI_Info = DCI_Info1)$Value);
-    }
-    if(objectType == "Species"){
-      isFormulaInFirst = as.logical(getSpeciesInitialValue(path_id = idFirst, options = list(Type = "current", Property = "IsFormula"), DCI_Info = DCI_Info1)$Value);
-    }
+    isFormulaInFirst = as.logical(getObjectProperty(objectType = options$objectType, path_id = idFirst, DCI_Info = DCI_Info1, property = "IsFormula"));
+    
     #Formula string (empty if the object is non-formula)
     formulaStringFirst = "";
     if(isFormulaInFirst){
-      if(objectType == "Parameter"){
-        formulaStringFirst = getParameter(path_id = idFirst, options = list(Type = "current", Property = "Formula"), DCI_Info = DCI_Info1)$Value;
-      }
-      if(objectType == "Species"){
-        formulaStringFirst = getSpeciesInitialValue(path_id = idFirst, options = list(Type = "current", Property = "Formula"), DCI_Info = DCI_Info1)$Value;
-      }
-      if(objectType == "Observer"){
-        formulaStringFirst = getObserverFormula(path_id = idFirst, DCI_Info = DCI_Info1)$Value;
-      }
+      formulaStringFirst = getObjectProperty(objectType = options$objectType, path_id = idFirst, DCI_Info = DCI_Info1, property = "Formula");
     }
     
     #Find the entry with the same path in the second simulation.
     simNameForSearch = "";
     if (pathIncludesSimName){
-      simNameForSearch = simName2;
+      simNameForSearch = options$simName2;
     }
-    if(objectType == "Parameter"){
-      secondObject = existsParameter(path_id = paste(simNameForSearch, objectPath, sep = "|"), options = list(Type = "readonly"), DCI_Info = DCI_Info2);
-    }
-    if(objectType == "Species"){
-      secondObject = existsSpeciesInitialValue(path_id = paste(simNameForSearch, objectPath, sep = "|"), options = list(Type = "readonly"), DCI_Info = DCI_Info2);
-    }
-    if(objectType == "Observer"){
-      secondObject = existsObserver(path_id = paste(simNameForSearch, objectPath, sep = "|"), DCI_Info = DCI_Info2);
-    }
+    secondObject = getObjectExistance(objectType = options$objectType, path_id = paste(simNameForSearch, objectPath, sep = "|"), DCI_Info = DCI_Info2);
+    
     if((existsInSecond = secondObject$isExisting)){
       #ID of the object in the second simulation
       idSecond = allObjects2$ID[secondObject$Index];
+      
       #Value of the object in the second simulation
-      secondValue = NaN;
-      if(objectType == "Parameter"){
-        secondValue = getParameter(path_id = idSecond, options = list(Type = "current"), DCI_Info = DCI_Info2)$Value;
-      }
-      if(objectType == "Species"){
-        secondValue = getSpeciesInitialValue(path_id = idSecond, options = list(Type = "current"), DCI_Info = DCI_Info2)$Value;
-      }
+      secondValue = getObjectProperty(objectType = options$objectType, path_id = idSecond, DCI_Info = DCI_Info2, property = "Value");
+      
       #Is the object defined by a formula in the second simulation?
-      isFormulaInSecond = TRUE;
-      if(objectType == "Parameter"){
-        isFormulaInSecond = as.logical(getParameter(path_id = idSecond, options = list(Type = "current", Property = "IsFormula"), DCI_Info = DCI_Info2)$Value);
-      }
-      if(objectType == "Species"){
-        isFormulaInSecond = as.logical(getSpeciesInitialValue(path_id = idSecond, options = list(Type = "current", Property = "IsFormula"), DCI_Info = DCI_Info2)$Value);
-      }
+      isFormulaInSecond = as.logical(getObjectProperty(objectType = options$objectType, path_id = idSecond, DCI_Info = DCI_Info2, property = "IsFormula"));
+      
       #Formula string (empty if the object is non-formula)
       formulaStringSecond = "";
       if(isFormulaInSecond){
-        if(objectType == "Parameter"){
-          formulaStringSecond = getParameter(path_id = idSecond, options = list(Type = "current", Property = "Formula"), DCI_Info = DCI_Info2)$Value;
-        }
-        if(objectType == "Species"){
-          formulaStringSecond = getSpeciesInitialValue(path_id = idSecond, options = list(Type = "current", Property = "Formula"), DCI_Info = DCI_Info2)$Value;
-        }
-        if(objectType == "Observer"){
-          formulaStringSecond = getObserverFormula(path_id = idSecond, DCI_Info = DCI_Info2)$Value;
-        }
+        formulaStringSecond = getObjectProperty(objectType = options$objectType, path_id = idSecond, DCI_Info = DCI_Info2, property = "Formula")
       }
       
       #Compare objects
-      identical = (isTRUE(all.equal.numeric(firstValue, secondValue, tolerance = numTolerance)));
-      if (!ignoreFormula){
+      identical = (isTRUE(all.equal.numeric(firstValue, secondValue, tolerance = options$numTolerance)));
+      if (!options$ignoreFormula){
         identical = (identical & (isFormulaInFirst == isFormulaInSecond) & isTRUE(all.equal.character(formulaStringFirst, formulaStringSecond)));
       }
-      #Mark the object idnex as compared.
+      #Mark the object's idnex as compared.
       idxComparedInSecond = c(idxComparedInSecond, secondObject$Index);
     }
     #Object is not in second simulation
@@ -144,156 +145,52 @@ compareStructures = function(objectType, DCI_Info1, DCI_Info2, simName1, simName
     
     #If the objects are not identical, create an entry in differences-list.
     if( !identical ){
-      objectsPaths = c(objectsPaths, objectPath);
-      existanceInFirst = c(existanceInFirst, existsInFirst);
-      existanceInSecond = c(existanceInSecond, existsInSecond);
-      valuesFirst = c(valuesFirst, firstValue);
-      valuesSecond = c(valuesSecond, secondValue);
-      formulaFlagsFirst = c(formulaFlagsFirst, isFormulaInFirst);
-      formulaFlagsSecond = c(formulaFlagsSecond, isFormulaInSecond);
-      formulaStringsFirst = c(formulaStringsFirst, formulaStringFirst);
-      formulaStringsSecond = c(formulaStringsSecond, formulaStringSecond);
+      objects_diff$Path = c(objects_diff$Path, objectPath);
+      objects_diff$isExistingFirst = c(objects_diff$isExistingFirst, existsInFirst);
+      objects_diff$isExistingSecond = c(objects_diff$isExistingSecond, existsInSecond);
+      objects_diff$ValueFirst = c(objects_diff$ValueFirst, firstValue);
+      objects_diff$ValueSecond = c(objects_diff$ValueSecond, secondValue);
+      objects_diff$IsFormulaFirst = c(objects_diff$IsFormulaFirst, isFormulaInFirst);
+      objects_diff$IsFormulaSecond = c(objects_diff$IsFormulaSecond, isFormulaInSecond);
+      objects_diff$FormulaFirst  = c(objects_diff$FormulaFirst , formulaStringFirst);
+      objects_diff$FormulaSecond = c(objects_diff$FormulaSecond, formulaStringSecond);
     }
   }
   
-  #Iterate through objects from the second simulation that have not been compared and compare them to the objects from the first simulation.
-  for (secondIdx in setdiff(allObjects2$Index, idxComparedInSecond)){
-    #Flag determining whether the objects are identical in both simulations.
-    identical = TRUE;
-    #Flag determining whether the object exists in the second simulation
-    existsInSecond = TRUE;
-    #Get the path of the object
-    objectInfo = splitSimNameFromPath(allObjects1$Path[firstIdx]);
-    objectPath = objectInfo$Path;
-    #Some parameters (e.g., 'AbsTol') do not require the name of the simulation as path prefix.
-    #To correctly construct the path in the other simulation, mark whether addition of simulation name is required.
-    pathIncludesSimName = TRUE;
-    if (! (nchar(objectInfo$SimName) > 0) ){
-      pathIncludesSimName = FALSE;
-    }
-    #ID of the object in the second simulation
-    idSecond = allObjects2$ID[secondIdx];
-    
-    #Value of the object in the second simulation
-    secondValue = NaN;
-    if(objectType == "Parameter"){
-      secondValue = getParameter(path_id = idSecond, options = list(Type = "current"), DCI_Info = DCI_Info2)$Value;
-    }
-    if(objectType == "Species"){
-      secondValue = getSpeciesInitialValue(path_id = idSecond, options = list(Type = "current"), DCI_Info = DCI_Info2)$Value;
-    }
-    
-    #Is the object defined by a formula in the second simulation?
-    isFormulaInSecond = TRUE;
-    if(objectType == "Parameter"){
-      isFormulaInSecond = as.logical(getParameter(path_id = idSecond, options = list(Type = "current", Property = "IsFormula"), DCI_Info = DCI_Info2)$Value);
-    }
-    if(objectType == "Species"){
-      isFormulaInSecond = as.logical(getSpeciesInitialValue(path_id = idSecond, options = list(Type = "current", Property = "IsFormula"), DCI_Info = DCI_Info2)$Value);
-    }
-    #Formula string (empty if the object is non-formula)
-    formulaStringSecond = "";
-    if(isFormulaInSecond){
-      if(objectType == "Parameter"){
-        formulaStringSecond = getParameter(path_id = idSecond, options = list(Type = "current", Property = "Formula"), DCI_Info = DCI_Info2)$Value;
-      }
-      if(objectType == "Species"){
-        formulaStringSecond = getSpeciesInitialValue(path_id = idSecond, options = list(Type = "current", Property = "Formula"), DCI_Info = DCI_Info2)$Value;
-      }
-      if(objectType == "Observer"){
-        formulaStringSecond = getObserverFormula(path_id = idSecond, DCI_Info = DCI_Info2)$Value;
-      }
-    }
-    
-    #Find the object with the same path in the first simulation.
-    simNameForSearch = "";
-    if (pathIncludesSimName){
-      simNameForSearch = simName1;
-    }
-    if(objectType == "Parameter"){
-      firstObject = existsParameter(path_id = paste(simNameForSearch, objectPath, sep = "|"), options = list(Type = "readonly"), DCI_Info = DCI_Info1);
-    }
-    if(objectType == "Species"){
-      firstObject = existsSpeciesInitialValue(path_id = paste(simNameForSearch, objectPath, sep = "|"), options = list(Type = "readonly"), DCI_Info = DCI_Info1);
-    }
-    if(objectType == "Observer"){
-      firstObject = existsObserver(path_id = paste(simNameForSearch, objectPath, sep = "|"), DCI_Info = DCI_Info1);
-    }
-    
-    if((existsInFirst = firstObject$isExisting)){
-      #ID of the object in the first simulation
-      idFirst = allObjects1$ID[firstObject$Index];
-      #Value of the object in the first simulation
-      firstValue = NaN;
-      if(objectType == "Parameter"){
-        firstValue = getParameter(path_id = idFirst, options = list(Type = "current"), DCI_Info = DCI_Info1)$Value;
-      }
-      if(objectType == "Species"){
-        firstValue = getSpeciesInitialValue(path_id = idFirst, options = list(Type = "current"), DCI_Info = DCI_Info1)$Value;
-      }
-      
-      #Is the object defined by a formula in the first simulation?
-      isFormulaInFirst = TRUE;
-      if(objectType == "Parameter"){
-        isFormulaInFirst = as.logical(getParameter(path_id = idFirst, options = list(Type = "current", Property = "IsFormula"), DCI_Info = DCI_Info1)$Value);
-      }
-      if(objectType == "Species"){
-        isFormulaInFirst = as.logical(getSpeciesInitialValue(path_id = idFirst, options = list(Type = "current", Property = "IsFormula"), DCI_Info = DCI_Info1)$Value);
-      }
-      #Formula string (empty if parameter is non-formula)
-      formulaStringFirst = "";
-      if(isFormulaInFirst){
-        if(objectType == "Parameter"){
-          formulaStringFirst = getParameter(path_id = idFirst, options = list(Type = "current", Property = "Formula"), DCI_Info = DCI_Info1)$Value;
-        }
-        if(objectType == "Species"){
-          formulaStringFirst = getSpeciesInitialValue(path_id = idFirst, options = list(Type = "current", Property = "Formula"), DCI_Info = DCI_Info1)$Value;
-        }
-        if(objectType == "Observer"){
-          formulaStringFirst = getObserverFormula(path_id = idFirst, DCI_Info = DCI_Info1)$Value;
-        }
-      }
-      
-      #Compare the objects
-      identical = (isTRUE(all.equal.numeric(firstValue, secondValue, tolerance = numTolerance)));
-      if (!ignoreFormula){
-        identical = (identical & (isFormulaInFirst == isFormulaInSecond) & isTRUE(all.equal.character(formulaStringFirst, formulaStringSecond)));
-      }
-    }
-    #Object is not in first simulation
-    else{
-      identical = FALSE;
-      firstValue = NaN;
-      isFormulaInFirst = NaN;
-      formulaStringFirst = "";
-    }
-    
-    #If the objects are not identical, create an entry in differences-list.
-    if( !identical ){
-      objectsPaths = c(objectsPaths, objectPath);
-      existanceInFirst = c(existanceInFirst, existsInFirst);
-      existanceInSecond = c(existanceInSecond, existsInSecond);
-      valuesFirst = c(valuesFirst, firstValue);
-      valuesSecond = c(valuesSecond, secondValue);
-      formulaFlagsFirst = c(formulaFlagsFirst, isFormulaInFirst);
-      formulaFlagsSecond = c(formulaFlagsSecond, isFormulaInSecond);
-      formulaStringsFirst = c(formulaStringsFirst, formulaStringFirst);
-      formulaStringsSecond = c(formulaStringsSecond, formulaStringSecond);
-    }
-  }
+  return(list(diffs = objects_diff, comparedInSecond = idxComparedInSecond));
+}
+
+#objectType can be "Parameter", "Species", or "Observer"
+compareStructures = function(DCI_Info1, DCI_Info2, options){
+  #Compare all objects from the first simulation to the objects from the second simulation.
+  comparisonResult_first = compareObjects(DCI_Info1 = DCI_Info1, DCI_Info2 = DCI_Info2, options = options);
   
-  objects_diff$Path = objectsPaths;
-  objects_diff$isExistingFirst = existanceInFirst;
-  objects_diff$isExistingSecond = existanceInSecond;
-  objects_diff$ValueFirst = valuesFirst;
-  objects_diff$ValueSecond = valuesSecond;
-  objects_diff$IsFormulaFirst = formulaFlagsFirst;
-  objects_diff$IsFormulaSecond = formulaFlagsSecond;
-  objects_diff$FormulaFirst = formulaStringsFirst;
-  objects_diff$FormulaSecond = formulaStringsSecond;
+  #Compare objects from the second simulation that have not been compared before to the objects from the first simulation.
+  comparisonResult_second = compareObjects(DCI_Info1 = DCI_Info2, DCI_Info2 = DCI_Info1, options = options, excludeIdx = comparisonResult_first$comparedInSecond);
+
+  #Combine results of the comparisons
+  objects_diff = list();
+  objects_diff$Path = c(comparisonResult_first$diffs$Path, comparisonResult_second$diffs$Path);
+  objects_diff$isExistingFirst = c(comparisonResult_first$diffs$isExistingFirst, comparisonResult_second$diffs$isExistingSecond);
+  #Does the object exist in the second simulation?
+  objects_diff$isExistingSecond = c(comparisonResult_first$diffs$isExistingSecond, comparisonResult_second$diffs$isExistingFirst);
+  #Numerical value of the object in the first simulation.
+  objects_diff$ValueFirst = c(comparisonResult_first$diffs$ValueFirst, comparisonResult_second$diffs$ValueSecond);
+  #Numerical value of the object in the second simulation.
+  objects_diff$ValueSecond = c(comparisonResult_first$diffs$ValueSecond, comparisonResult_second$diffs$ValueFirst);
+  #Is the objects value defined by a formula in the first simulation?
+  objects_diff$IsFormulaFirst = c(comparisonResult_first$diffs$IsFormulaFirst, comparisonResult_second$diffs$IsFormulaSecond);
+  #Is the objects value defined by a formula in the second simulation?
+  objects_diff$IsFormulaSecond = c(comparisonResult_first$diffs$IsFormulaSecond, comparisonResult_second$diffs$IsFormulaFirst);
+  #Formula string defining the value of the object in the first simulation. Empty if no formula used.
+  objects_diff$FormulaFirst = c(comparisonResult_first$diffs$FormulaFirst, comparisonResult_second$diffs$FormulaSecond);
+  #Formula string defining the value of the object in the second simulation. Empty if no formula used.
+  objects_diff$FormulaSecond = c(comparisonResult_first$diffs$FormulaSecond, comparisonResult_second$diffs$FormulaFirst);
+
   return(objects_diff);
 }
 
+#Compare output patterns.
 compareSimulationTime = function(simTime1, simTime2){
   identical = TRUE;
   #Compare time pattern by size and element-wise
@@ -303,71 +200,50 @@ compareSimulationTime = function(simTime1, simTime2){
   return(identical);
 }
 
+#Append comparison results of a specific type to a string that will be written to a file.
+appendResultsToString = function(outString, objectsResults){
+  outString = c(outString, paste("Path", "Exists in first", "Exists in second", "Value in first", "Value in second", "Is formula in first", "Is formula in second", "Formula string in first", "Formula string in second", sep = "\t"));
+  if (length(objectsResults) > 0){
+    for (i in 1 : length(objectsResults$Path)){
+      outString = c(outString, paste(
+        objectsResults$Path[i],
+        objectsResults$isExistingFirst[i],
+        objectsResults$isExistingSecond[i],
+        objectsResults$ValueFirst[i],
+        objectsResults$ValueSecond[i],
+        objectsResults$IsFormulaFirst[i],
+        objectsResults$IsFormulaSecond[i],
+        objectsResults$FormulaFirst[i],
+        objectsResults$FormulaSecond[i],
+        sep = "\t"));
+    }
+  }
+  return(outString);
+}
+
+#Write results into a CSV file.
 writeToCSV = function(CSV_path, results){
   dirname <- dirname(CSV_path)
   if (!file.exists(dirname)) {
     dir.create(dirname, recursive=TRUE)
   }
+  
+  #Build the output string.
   outString = "Simulation names";
   outString = c(outString, paste(results$SimNames[1], results$SimNames[2], sep = "\t"));
   
   outString = c(outString, "Parameter differences:");
-  outString = c(outString, paste("Path", "Exists in first", "Exists in second", "Value in first", "Value in second", "Is formula in first", "Is formula in second", "Formula string in first", "Formula string in second", sep = "\t"));
-  if (length(results$Params_diff) > 0){
-    for (i in 1 : length(results$Params_diff$Path)){
-      outString = c(outString, paste(
-        results$Params_diff$Path[i],
-        results$Params_diff$isExistingFirst[i],
-        results$Params_diff$isExistingSecond[i],
-        results$Params_diff$ValueFirst[i],
-        results$Params_diff$ValueSecond[i],
-        results$Params_diff$IsFormulaFirst[i],
-        results$Params_diff$IsFormulaSecond[i],
-        results$Params_diff$FormulaFirst[i],
-        results$Params_diff$FormulaSecond[i],
-        sep = "\t"));
-    }
-  }
-  
+  outString = appendResultsToString(outString = outString, objectsResults = results$Params_diff);
+
   outString = c(outString, "Species differences:");
-  outString = c(outString, paste("Path", "Exists in first", "Exists in second", "Value in first", "Value in second", "Is formula in first", "Is formula in second", "Formula string in first", "Formula string in second", sep = "\t"));
-  if (length(results$Species_diff) > 0){
-    for (i in 1 : length(results$Species_diff$Path)){
-      outString = c(outString, paste(
-        results$Species_diff$Path[i],
-        results$Species_diff$isExistingFirst[i],
-        results$Species_diff$isExistingSecond[i],
-        results$Species_diff$ValueFirst[i],
-        results$Species_diff$ValueSecond[i],
-        results$Species_diff$IsFormulaFirst[i],
-        results$Species_diff$IsFormulaSecond[i],
-        results$Species_diff$FormulaFirst[i],
-        results$Species_diff$FormulaSecond[i],
-        sep = "\t"));
-    }
-  }
+  outString = appendResultsToString(outString = outString, objectsResults = results$Species_diff);
   
   outString = c(outString, "Observer differences:");
-  outString = c(outString, paste("Path", "Exists in first", "Exists in second", "Value in first", "Value in second", "Is formula in first", "Is formula in second", "Formula string in first", "Formula string in second", sep = "\t"));
-  if (length(results$Observer_diff) > 0){
-    for (i in 1 : length(results$Observer_diff$Path)){
-      outString = c(outString, paste(
-        results$Observer_diff$Path[i],
-        results$Observer_diff$isExistingFirst[i],
-        results$Observer_diff$isExistingSecond[i],
-        results$Observer_diff$ValueFirst[i],
-        results$Observer_diff$ValueSecond[i],
-        results$Observer_diff$IsFormulaFirst[i],
-        results$Observer_diff$IsFormulaSecond[i],
-        results$Observer_diff$FormulaFirst[i],
-        results$Observer_diff$FormulaSecond[i],
-        sep = "\t"));
-    }
-  }
+  outString = appendResultsToString(outString = outString, objectsResults = results$Observer_diff);
+  
   outString = c(outString, paste0("Time pattern identical\t", results$TimeIdentical));
   
-  
-  write.table(x = outString, file = resultsCSV_path, row.names = FALSE, col.names = FALSE, dec = ",");
+  write.table(x = outString, file = CSV_path, row.names = FALSE, col.names = FALSE, dec = ",");
 }
 
 #' Compares two simulations for differences.
@@ -380,7 +256,7 @@ writeToCSV = function(CSV_path, results){
 #' @param DCI_Info1 DCI_Info of the first simulation
 #' @param DCI_Info2 DCI_Info of the second simulation
 #' @param numTolerance Maximal numeric deviation which is accepted as equal. Default value is 1e-8.
-#' @param resultsCSV_path A path to a file where the results of the comparison are writen to. If emtpy, no output into a file is performed. If a file with the given path exists, it will be 
+#' @param resultsCSV_path A path to a tab-separated file where the results of the comparison are writen to. If emtpy, no output into a file is performed. If a file with the given path exists, it will be 
 #' overwritten; otherwise, a new file is created. Emtpy by default.
 #' @param ignoreFormula If true, only values of parameters or molecule start values are compared. If false, formula strings are compared. FALSE by default.
 #'
@@ -394,8 +270,8 @@ writeToCSV = function(CSV_path, results){
 #' 'ValueSecond' value of the object in the second simulation,
 #' 'IsFormulaFirst' boolean value whether the object is defined by a formula in the first simulation,
 #' 'IsFormulaSecond' boolean value whether the object is defined by a formula in the second simulation,
-#' 'FormulaFirst' string reprentation of the parameter value in the first simulation (empty if parameter is not defined by a formula),
-#' 'FormulaSecond' string reprentation of the parameter value in the second simulation (empty if parameter is not defined by a formula).
+#' 'FormulaFirst' string reprentation of the object's formula in the first simulation (empty if object is not defined by a formula),
+#' 'FormulaSecond' string reprentation of the object's formula in the second simulation (empty if object is not defined by a formula).
 #' 'TimeIdentical' is a boolean defining whether the time-patterns are equal in both simulations.
 #' If DCI_Info1 and DCI_Info2 have the same handle-ID, identity of the simulations is assumed without comparison.
 #' If no differences are found, an empty list is returned for the corresponding entry (parameters, species, observers).
@@ -473,20 +349,17 @@ compareSimulations = function(DCI_Info1 = {}, DCI_Info2 = {}, numTolerance = 1e-
   }
   
   #Compare parameters, species, and observers.
-  params_diff = compareStructures("Parameter", DCI_Info1, DCI_Info2, numTolerance = numTolerance, simName1 = simName1, simName2 = simName2, ignoreFormula = ignoreFormula);
-  species_diff = compareStructures("Species", DCI_Info1, DCI_Info2, numTolerance = numTolerance, simName1 = simName1, simName2 = simName2, ignoreFormula = ignoreFormula);
-  observer_diff = compareStructures("Observer", DCI_Info1, DCI_Info2,numTolerance = numTolerance, simName1 = simName1, simName2 = simName2, ignoreFormula = ignoreFormula);
+  comparisonOptions = list(objectType = "Parameter", simName1 = simName1, simName2 = simName2, ignoreFormula = ignoreFormula, numTolerance = numTolerance);
+  results$Params_diff = compareStructures(DCI_Info1 = DCI_Info1, DCI_Info2 = DCI_Info2, options = comparisonOptions);
+  comparisonOptions$objectType = "Species";
+  results$Species_diff = compareStructures(DCI_Info1 = DCI_Info1, DCI_Info2 = DCI_Info2, options = comparisonOptions);
+  comparisonOptions$objectType = "Observer";
+  results$Observer_diff = compareStructures(DCI_Info1 = DCI_Info1, DCI_Info2 = DCI_Info2, options = comparisonOptions);
   
   #Compare simulation time
   simTime1 = getSimulationTime(DCI_Info = DCI_Info1);
   simTime2 = getSimulationTime(DCI_Info = DCI_Info2);
-  timeIdentical = compareSimulationTime(simTime1, simTime2);
-  
-  #Store parameter differences
-  results$Params_diff = params_diff;
-  results$Species_diff = species_diff;
-  results$Observer_diff = observer_diff;
-  results$TimeIdentical = timeIdentical;
+  results$TimeIdentical = compareSimulationTime(simTime1, simTime2);
   
   #If a path to output file a specified, write the results into a CSV-file.
   if (!resultsCSV_path == "")

--- a/tests/runit.compareSimulations.R
+++ b/tests/runit.compareSimulations.R
@@ -1,8 +1,10 @@
 #require(RUnit, quietly=TRUE)
 #require(MoBiToolboxForR, quietly=TRUE)
-simModelXML1 <- "./tests/models/black american girl.xml"
+simModelXML1 <- "./tests/models/black american girl.xml";
+simModelXML2 = "./tests/models/default man.xml";
 dci_info1 = initSimulation(simModelXML1, whichInitParam = "none");
 dci_info2 = initSimulation(simModelXML1, whichInitParam = "none");
+dci_info3 = initSimulation(simModelXML2, whichInitParam = "none");
 resultsPath = file.path(getwd(), "CurrentComparison.csv");
 
 #Check for both DCI_Info!
@@ -51,7 +53,7 @@ test.ignoreFormulainvalid = function(){
 
 #Same DCI - results identical
 test.sameDCI = function(){
-  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info1, resultsCSV_path = resultsPath);
+  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info1);#, resultsCSV_path = resultsPath);
   checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
   checkEquals(length(diffs$Params_diff), 0);
   checkEquals(length(diffs$Species_diff), 0);
@@ -61,7 +63,7 @@ test.sameDCI = function(){
 
 #Different DCI, same simulation, ignoreFormula = TRUE, results should be identical
 test.simulationsIdentical_ignoreFormula = function(){
-  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info2, ignoreFormula = TRUE, resultsCSV_path = resultsPath);
+  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info2, ignoreFormula = TRUE);#, resultsCSV_path = resultsPath);
   checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
   checkEquals(length(diffs$Params_diff), 0);
   checkEquals(length(diffs$Species_diff), 0);
@@ -71,7 +73,7 @@ test.simulationsIdentical_ignoreFormula = function(){
 
 #Different DCI, same simulation, ignoreFormula = FALSE, results should be identical
 test.simulationsIdentical_notIgnoreFormula = function(){
-  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info2, ignoreFormula = FALSE, resultsCSV_path = resultsPath);
+  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info2, ignoreFormula = FALSE);#, resultsCSV_path = resultsPath);
   checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
   checkEquals(length(diffs$Params_diff), 0);
   checkEquals(length(diffs$Species_diff), 0);
@@ -93,7 +95,7 @@ test.simulationsIdentical_InitAll_notIgnoreFormula = function(){
 #Different DCI, same simulation, but one simulation with initialized formulas, ignoreFormula = TRUE, results should be identical
 test.simulationsIdentical_InitAll_ignoreFormula = function(){
   dci_info2_diff = initSimulation(simModelXML1, whichInitParam = "all");
-  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info2_diff, ignoreFormula = TRUE, resultsCSV_path = resultsPath);
+  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info2_diff, ignoreFormula = TRUE);#, resultsCSV_path = resultsPath);
   checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
   checkEquals(length(diffs$Params_diff), 0);
   checkEquals(length(diffs$Species_diff), 0);
@@ -112,14 +114,14 @@ test.simulationsIdentical_InitParam_sameValue = function(){
   dci_info1_diff = setParameter(80, paramPath, DCI_Info = dci_info1_diff);
   dci_info2_diff = setParameter(80, paramPath, DCI_Info = dci_info2_diff);
   
-  diffs = compareSimulations(DCI_Info1 = dci_info1_diff, DCI_Info2 = dci_info2_diff, ignoreFormula = TRUE, resultsCSV_path = resultsPath);
+  diffs = compareSimulations(DCI_Info1 = dci_info1_diff, DCI_Info2 = dci_info2_diff, ignoreFormula = TRUE);#, resultsCSV_path = resultsPath);
   checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
   checkEquals(length(diffs$Params_diff), 0);
   checkEquals(length(diffs$Species_diff), 0);
   checkEquals(length(diffs$Observer_diff), 0);
   checkEquals(diffs$TimeIdentical, TRUE);
   
-  diffs = compareSimulations(DCI_Info1 = dci_info1_diff, DCI_Info2 = dci_info2_diff, ignoreFormula = FALSE, resultsCSV_path = resultsPath);
+  diffs = compareSimulations(DCI_Info1 = dci_info1_diff, DCI_Info2 = dci_info2_diff, ignoreFormula = FALSE);#, resultsCSV_path = resultsPath);
   checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
   checkEquals(length(diffs$Params_diff), 0);
   checkEquals(length(diffs$Species_diff), 0);
@@ -138,14 +140,14 @@ test.simulationsIdentical_InitParam_diffValue = function(){
   dci_info1_diff = setParameter(80, paramPath, DCI_Info = dci_info1_diff);
   dci_info2_diff = setParameter(70, paramPath, DCI_Info = dci_info2_diff);
   
-  diffs = compareSimulations(DCI_Info1 = dci_info1_diff, DCI_Info2 = dci_info2_diff, ignoreFormula = TRUE, resultsCSV_path = resultsPath);
+  diffs = compareSimulations(DCI_Info1 = dci_info1_diff, DCI_Info2 = dci_info2_diff, ignoreFormula = TRUE);#, resultsCSV_path = resultsPath);
   checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
   checkEquals(length(diffs$Params_diff), 9);
   checkEquals(length(diffs$Species_diff), 0);
   checkEquals(length(diffs$Observer_diff), 0);
   checkEquals(diffs$TimeIdentical, TRUE);
   
-  diffs = compareSimulations(DCI_Info1 = dci_info1_diff, DCI_Info2 = dci_info2_diff, ignoreFormula = FALSE, resultsCSV_path = resultsPath);
+  diffs = compareSimulations(DCI_Info1 = dci_info1_diff, DCI_Info2 = dci_info2_diff, ignoreFormula = FALSE);#, resultsCSV_path = resultsPath);
   checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
   checkEquals(length(diffs$Params_diff), 9);
   checkEquals(length(diffs$Species_diff), 0);
@@ -154,8 +156,9 @@ test.simulationsIdentical_InitParam_diffValue = function(){
 }
 
 test.timePaternChanged = function(){
-  dci_info1 = setSimulationTime(timepoints = c(0, 10), DCI_Info = dci_info1);
-  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info2, ignoreFormula = FALSE, resultsCSV_path = resultsPath);
+  current_dci_info1 = dci_info1;
+  current_dci_info1 = setSimulationTime(timepoints = c(0, 10), DCI_Info = current_dci_info1);
+  diffs = compareSimulations(DCI_Info1 = current_dci_info1, DCI_Info2 = dci_info2, ignoreFormula = FALSE);#, resultsCSV_path = resultsPath);
   checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
   checkEquals(length(diffs$Params_diff), 0);
   checkEquals(length(diffs$Species_diff), 0);

--- a/tests/runit.compareSimulations.R
+++ b/tests/runit.compareSimulations.R
@@ -1,0 +1,164 @@
+#require(RUnit, quietly=TRUE)
+#require(MoBiToolboxForR, quietly=TRUE)
+simModelXML1 <- "./tests/models/black american girl.xml"
+dci_info1 = initSimulation(simModelXML1, whichInitParam = "none");
+dci_info2 = initSimulation(simModelXML1, whichInitParam = "none");
+resultsPath = file.path(getwd(), "CurrentComparison.csv");
+
+#Check for both DCI_Info!
+test.EmptyDCI_Info <- function() {
+  #Empty DCI_Info1
+  checkException(compareSimulations(DCI_Info2 = dci_info1));
+  #Emtpy DCI_Info2
+  checkException(compareSimulations(DCI_Info1 = dci_info1));
+  #Both DCI_Info emtpy
+  checkException(compareSimulations());
+}
+
+#Check for tolerance positive
+test.numericalTolerance = function(){
+  checkException(compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info1, numTolerance = -1));
+}
+
+test.OverwrittingExistingFile <- function() {
+  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info1, resultsCSV_path = resultsPath);
+  checkTrue(file.exists(resultsPath));
+  
+  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info1, resultsCSV_path = resultsPath);
+  checkTrue(file.exists(resultsPath))
+  file.remove(resultsPath)
+}
+
+test.CreateNonExistingFolder <- function() {
+  path <- file.path(getwd(), "NewFolder", "CurrentComparison.csv")
+  
+  checkTrue(!file.exists(dirname(path)))
+  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info1, resultsCSV_path = path);
+  checkTrue(file.exists(path))
+
+  file.remove(path)
+  unlink(dirname(path), recursive=TRUE)
+}
+
+#TO DO
+test.resultsCSV_path_invalid = function(){
+}
+
+#non-boolean ingnoreFormula
+test.ignoreFormulainvalid = function(){
+  checkException(compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info1, ignoreFormula = "-1"));
+}
+
+#Same DCI - results identical
+test.sameDCI = function(){
+  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info1, resultsCSV_path = resultsPath);
+  checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
+  checkEquals(length(diffs$Params_diff), 0);
+  checkEquals(length(diffs$Species_diff), 0);
+  checkEquals(length(diffs$Observer_diff), 0);
+  checkEquals(diffs$TimeIdentical, TRUE);
+}
+
+#Different DCI, same simulation, ignoreFormula = TRUE, results should be identical
+test.simulationsIdentical_ignoreFormula = function(){
+  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info2, ignoreFormula = TRUE, resultsCSV_path = resultsPath);
+  checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
+  checkEquals(length(diffs$Params_diff), 0);
+  checkEquals(length(diffs$Species_diff), 0);
+  checkEquals(length(diffs$Observer_diff), 0);
+  checkEquals(diffs$TimeIdentical, TRUE);
+}
+
+#Different DCI, same simulation, ignoreFormula = FALSE, results should be identical
+test.simulationsIdentical_notIgnoreFormula = function(){
+  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info2, ignoreFormula = FALSE, resultsCSV_path = resultsPath);
+  checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
+  checkEquals(length(diffs$Params_diff), 0);
+  checkEquals(length(diffs$Species_diff), 0);
+  checkEquals(length(diffs$Observer_diff), 0);
+  checkEquals(diffs$TimeIdentical, TRUE);
+}
+
+#Different DCI, same simulation, but one simulation with initialized formulas, ignoreFormula = FALSE, results should not be identical
+test.simulationsIdentical_InitAll_notIgnoreFormula = function(){
+  dci_info2_diff = initSimulation(simModelXML1, whichInitParam = "all");
+  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info2_diff, ignoreFormula = FALSE, resultsCSV_path = resultsPath);
+  checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
+  checkEquals(length(diffs$Params_diff), 9);
+  checkEquals(length(diffs$Species_diff), 9);
+  checkEquals(length(diffs$Observer_diff), 9);
+  checkEquals(diffs$TimeIdentical, TRUE);
+}
+
+#Different DCI, same simulation, but one simulation with initialized formulas, ignoreFormula = TRUE, results should be identical
+test.simulationsIdentical_InitAll_ignoreFormula = function(){
+  dci_info2_diff = initSimulation(simModelXML1, whichInitParam = "all");
+  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info2_diff, ignoreFormula = TRUE, resultsCSV_path = resultsPath);
+  checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
+  checkEquals(length(diffs$Params_diff), 0);
+  checkEquals(length(diffs$Species_diff), 0);
+  checkEquals(length(diffs$Observer_diff), 0);
+  checkEquals(diffs$TimeIdentical, TRUE);
+}
+
+#Different DCI, same simulation, same parameter initialized, same value set, results should be identical
+test.simulationsIdentical_InitParam_sameValue = function(){
+  paramPath = "*|Organism|Weight";
+  initStruct = list();
+  initStruct = initParameter(initStruct = initStruct, path_id = paramPath, initializeIfFormula = "always");
+  dci_info1_diff = initSimulation(simModelXML1, ParamList = initStruct);
+  dci_info2_diff = initSimulation(simModelXML1, ParamList = initStruct);
+  
+  dci_info1_diff = setParameter(80, paramPath, DCI_Info = dci_info1_diff);
+  dci_info2_diff = setParameter(80, paramPath, DCI_Info = dci_info2_diff);
+  
+  diffs = compareSimulations(DCI_Info1 = dci_info1_diff, DCI_Info2 = dci_info2_diff, ignoreFormula = TRUE, resultsCSV_path = resultsPath);
+  checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
+  checkEquals(length(diffs$Params_diff), 0);
+  checkEquals(length(diffs$Species_diff), 0);
+  checkEquals(length(diffs$Observer_diff), 0);
+  checkEquals(diffs$TimeIdentical, TRUE);
+  
+  diffs = compareSimulations(DCI_Info1 = dci_info1_diff, DCI_Info2 = dci_info2_diff, ignoreFormula = FALSE, resultsCSV_path = resultsPath);
+  checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
+  checkEquals(length(diffs$Params_diff), 0);
+  checkEquals(length(diffs$Species_diff), 0);
+  checkEquals(length(diffs$Observer_diff), 0);
+  checkEquals(diffs$TimeIdentical, TRUE);
+}
+
+#Different DCI, same simulation, same parameter initialized, different values set, results should not be identical
+test.simulationsIdentical_InitParam_diffValue = function(){
+  paramPath = "*|Organism|Weight";
+  initStruct = list();
+  initStruct = initParameter(initStruct = initStruct, path_id = paramPath, initializeIfFormula = "always");
+  dci_info1_diff = initSimulation(simModelXML1, ParamList = initStruct);
+  dci_info2_diff = initSimulation(simModelXML1, ParamList = initStruct);
+  
+  dci_info1_diff = setParameter(80, paramPath, DCI_Info = dci_info1_diff);
+  dci_info2_diff = setParameter(70, paramPath, DCI_Info = dci_info2_diff);
+  
+  diffs = compareSimulations(DCI_Info1 = dci_info1_diff, DCI_Info2 = dci_info2_diff, ignoreFormula = TRUE, resultsCSV_path = resultsPath);
+  checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
+  checkEquals(length(diffs$Params_diff), 9);
+  checkEquals(length(diffs$Species_diff), 0);
+  checkEquals(length(diffs$Observer_diff), 0);
+  checkEquals(diffs$TimeIdentical, TRUE);
+  
+  diffs = compareSimulations(DCI_Info1 = dci_info1_diff, DCI_Info2 = dci_info2_diff, ignoreFormula = FALSE, resultsCSV_path = resultsPath);
+  checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
+  checkEquals(length(diffs$Params_diff), 9);
+  checkEquals(length(diffs$Species_diff), 0);
+  checkEquals(length(diffs$Observer_diff), 0);
+  checkEquals(diffs$TimeIdentical, TRUE);
+}
+
+test.timePaternChanged = function(){
+  dci_info1 = setSimulationTime(timepoints = c(0, 10), DCI_Info = dci_info1);
+  diffs = compareSimulations(DCI_Info1 = dci_info1, DCI_Info2 = dci_info2, ignoreFormula = FALSE, resultsCSV_path = resultsPath);
+  checkEquals(diffs$SimNames[1], diffs$SimNames[2]);
+  checkEquals(length(diffs$Params_diff), 0);
+  checkEquals(length(diffs$Species_diff), 0);
+  checkEquals(length(diffs$Observer_diff), 0);
+  checkEquals(diffs$TimeIdentical, FALSE);
+}

--- a/tests/runit.getEndSimulationResult.R
+++ b/tests/runit.getEndSimulationResult.R
@@ -1,6 +1,7 @@
 #require(RUnit, quietly=TRUE)
 #require(MoBiToolboxForR, quietly=TRUE)
 simModelXML <- "./tests/models/black american girl.xml"
+standard_dci_info <- initSimulation(XML=simModelXML, whichInitParam="none")
 
 obsPath1 = "black american girl|Organism|PeripheralVenousBlood|MoleculeProperties|my Compound|OBSBloodCells";
 obsID1 = 97;
@@ -17,12 +18,12 @@ test.EmptyDCI_Info <- function() {
 }
 
 test.NotSimulated <- function() {
-  standard_dci_info <- initSimulation(XML=simModelXML, whichInitParam="none")
-  dci_info <- standard_dci_info
+  dci_info <- standard_dci_info;
   checkException(getSimulationResult(DCI_Info=dci_info))
 }
 
 test.byPathSpecies = function(){
+  dci_info <- processSimulation(DCI_Info = standard_dci_info);
   #existent
   endResult = getEndSimulationResult(path_id = speciesPath1, DCI_Info = dci_info);
   result = getSimulationResult(path_id = speciesPath1, DCI_Info = dci_info);
@@ -33,6 +34,7 @@ test.byPathSpecies = function(){
 }
 
 test.byIDSpecies = function(){
+  dci_info <- processSimulation(DCI_Info = standard_dci_info);
   #existent
   endResult = getEndSimulationResult(path_id = speciesID1, DCI_Info = dci_info);
   result = getSimulationResult(path_id = speciesID1, DCI_Info = dci_info);
@@ -53,6 +55,7 @@ test.byIDSpecies = function(){
 }
 
 test.byPathObserver = function(){
+  dci_info <- processSimulation(DCI_Info = standard_dci_info);
   #existent
   endResult = getEndSimulationResult(path_id = obsPath1, DCI_Info = dci_info);
   result = getSimulationResult(path_id = obsPath1, DCI_Info = dci_info);
@@ -63,6 +66,7 @@ test.byPathObserver = function(){
 }
 
 test.byIDObserver = function(){
+  dci_info <- processSimulation(DCI_Info = standard_dci_info);
   #existent
   endResult = getEndSimulationResult(path_id = obsID1, DCI_Info = dci_info);
   result = getSimulationResult(path_id = obsID1, DCI_Info = dci_info);

--- a/tests/runit.setSimulationTime.R
+++ b/tests/runit.setSimulationTime.R
@@ -101,10 +101,10 @@ test.SetSimulationTimePointsAndSimulate <- function(){
   #first 8 hours hourly 
   timepoints <- c((0:7)*60)
   dci_info <- setSimulationTime(c(1:60, timepoints=(0:7)*60), DCI_Info=dci_info)
-  processSimulation(DCI_Info=dci_info)
+  dci_info = processSimulation(DCI_Info=dci_info);
   
   dci_info <- setSimulationTime(c(1:60), DCI_Info=dci_info)
-  processSimulation(DCI_Info=dci_info) # that failes currently with 
+  dci_info = processSimulation(DCI_Info=dci_info) # that failes currently with 
   # "Error in processSimulation(DCI_Info = dci_info) : "
   # "Unknown interval distribution type passed: ''"
   


### PR DESCRIPTION
#' Compares two simulations for differences.
#' Comparison is done for:
#' parameter existence, value and formula, 
#' species initial value existence, value and formula, 
#' observer existence and formula,
#' time pattern identity.
#'
#' @param DCI_Info1 DCI_Info of the first simulation
#' @param DCI_Info2 DCI_Info of the second simulation
#' @param numTolerance Maximal numeric deviation which is accepted as equal. Default value is 1e-8.
#' @param resultsCSV_path A path to a file where the results of the comparison are writen to. If emtpy, no output into a file is performed. If a file with the given path exists, it will be 
#' overwritten; otherwise, a new file is created. Emtpy by default.
#' @param ignoreFormula If true, only values of parameters or molecule start values are compared. If false, formula strings are compared. FALSE by default.
#'
#' @return
#' A list containing the lists 'SimNames', 'Params_diff', 'Species_diff', 'Observer_diff', and a boolean 'TimeIdentical'.
#' 'SimNames' contains the names of the compared simulations.
#' 'Params_diff', 'Species_diff' and 'Observer_diff' contain columns 'Path' with the path of the compared object,
#' 'isExistingFirst' boolean value whether the object exists in the first simulation,
#' 'isExistingSecond' boolean value whether the object  exists in the second simulation,
#' 'ValueFirst' value of the object in the first simulation,
#' 'ValueSecond' value of the object in the second simulation,
#' 'IsFormulaFirst' boolean value whether the object is defined by a formula in the first simulation,
#' 'IsFormulaSecond' boolean value whether the object is defined by a formula in the second simulation,
#' 'FormulaFirst' string reprentation of the parameter value in the first simulation (empty if parameter is not defined by a formula),
#' 'FormulaSecond' string reprentation of the parameter value in the second simulation (empty if parameter is not defined by a formula).
#' 'TimeIdentical' is a boolean defining whether the time-patterns are equal in both simulations.
#' If DCI_Info1 and DCI_Info2 have the same handle-ID, identity of the simulations is assumed without comparison.
#' If no differences are found, an empty list is returned for the corresponding entry (parameters, species, observers).